### PR TITLE
Directory-based builds / output 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mailgun": "^0.5.0",
     "mariadb": "^2.0.1-beta",
     "memcached": "^2.2.2",
+    "mkdirp": "^0.5.1",
     "mongoose": "^5.3.12",
     "mysql": "^2.16.0",
     "pdfkit": "^0.8.3",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,16 +7,20 @@ const glob = promisify(require("glob"));
 const bytes = require("bytes");
 
 async function main() {
-  const cli = await ncc(__dirname + "/../src/cli", {
+  const { code: cli, assets: cliAssets } = await ncc(__dirname + "/../src/cli", {
     externals: ["./index.js"]
   });
-  const index = await ncc(__dirname + "/../src/index", {
+  const { code: index, assets: indexAssets } = await ncc(__dirname + "/../src/index", {
     // we dont care about watching, so we don't want
     // to bundle it. even if we did want watching and a bigger
     // bundle, webpack (and therefore ncc) cannot currently bundle
     // chokidar, which is quite convenient
     externals: ["chokidar"]
   });
+
+  if (Object.keys(cliAssets).length || Object.keys(indexAssets).length) {
+    console.error('Assets emitted by core build, these need to be written into the dist directory');
+  }
 
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli);
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);

--- a/src/index.js
+++ b/src/index.js
@@ -82,12 +82,32 @@ module.exports = async (entry, { externals = [], minify = true } = {}) => {
   compiler.outputFileSystem = mfs;
   compiler.resolvers.normal.fileSystem = mfs;
   return new Promise((resolve, reject) => {
+    const assets = Object.create(null);
+    getFlatFiles(mfs.data, assets);
+    delete assets['/out.js'];
     compiler.run((err, stats) => {
       if (err) return reject(err);
       if (stats.hasErrors()) {
         return reject(new Error(stats.toString()));
       }
-      resolve(mfs.readFileSync("/out.js", "utf8"));
+      resolve({
+        code: mfs.readFileSync("/out.js", "utf8"),
+        assets
+      });
     });
   });
 };
+
+// this could be rewritten with actual FS apis / globs, but this is simpler
+function getFlatFiles (mfsData, output, curBase = '') {
+  for (const path of Object.keys(mfsData)) {
+    const item = mfsData[path];
+    const curPath = curBase + '/' + path;
+    // directory
+    if (item[""] = true)
+      getFlatFiles(item, output, curPath);
+    // file
+    else
+      output[curPath] = mfsData[path];
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // ignore e.g.: `.json` files
   if (!integrationTest.endsWith(".js")) continue;
   it(`should evaluate ${integrationTest} without errors`, async () => {
-    const code = await ncc(__dirname + "/integration/" + integrationTest);
+    const { code, assets } = await ncc(__dirname + "/integration/" + integrationTest);
     module.exports = null;
     eval(code);
     if ("function" !== typeof module.exports) {


### PR DESCRIPTION
This is an approach to #35 (although without the `run` command).

The API is changed to output `{ code, assets }`, where `assets` is an object of pathnames to buffers / strings (whatever webpack gives us from webpack asset emission).

The CLI is changed to output to `dist/index.js` by default including any assets.

I'm completely open to alternatives to any of this stuff... mainly just trying to get a base for fs relocations.