### PR TITLE
Fixup entry handling

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,13 +35,13 @@ switch (args._[0]) {
       process.exit(1);
     }
 
-    const ncc = require("./index.js")(require.resolve(args._[1] || "."), {
+    const ncc = require("./index.js")(require.resolve(resolve(args._[1] || ".")), {
       minify: !args["--no-minify"],
       externals: args["--external"]
     });
     
     ncc.then(({ code, assets }) => {
-      const outDir = args["--out"] || resolve(dist);
+      const outDir = args["--out"] || resolve("dist");
       const fs = require("fs");
       const mkdirp = require("mkdirp");
       mkdirp.sync(outDir);


### PR DESCRIPTION
I thought it would be nice for `ncc build pkg` to work where `pkg` is in node_modules, but this caused other regressions on the input it seems.

This reverts back to the previous resolve, and also fixes a bug where no output arg is given.