### PR TITLE
Fix main resolution

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,7 @@ switch (args._[0]) {
       process.exit(1);
     }
 
-    const ncc = require("./index.js")(require.resolve(resolve(args._[1] || ".")), {
+    const ncc = require("./index.js")(resolve(args._[1] || "."), {
       minify: !args["--no-minify"],
       externals: args["--external"]
     });


### PR DESCRIPTION
There was another bug here with the self-build causing webpack to intercept the require.resolve which was introduced to get package.json main to apply to the build input.

In theory, that makes it an ncc bug...

This is the quick fix, hopefully we can work out the better approach shortly.