### PR TITLE
Simple binary approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublish": "npm test"
   },
   "devDependencies": {
+    "@google-cloud/datastore": "^2.0.0",
     "@sentry/node": "^4.3.0",
     "acorn": "^6.0.4",
     "apollo-server-express": "^2.2.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,7 +62,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // ignore e.g.: `.json` files
   if (!integrationTest.endsWith(".js")) continue;
   it(`should evaluate ${integrationTest} without errors`, async () => {
-    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourceMap: true });
+    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourceMap: true, externals: ["grpc"] });
     module.exports = null;
     sourceMapSources[integrationTest] = map;
     // integration tests will load assets relative to __dirname

--- a/test/integration/google-datastore.js
+++ b/test/integration/google-datastore.js
@@ -1,0 +1,3 @@
+const datastore = require('@google-cloud/datastore');
+module.exports = () => {
+}


### PR DESCRIPTION
One of the major issues with binaries is that they are typically built for the target platform on install. This makes it very difficult to "statically" make binaries work for all platforms.

This PR brings back the google datastore test and gets it to pass by simply leaving the base-level binary package as an external of the build.

It may be possible to auto-detect binaries in this way (package.json with a `binary` field seems sufficient), and then inform users to keep them as dependencies so that this provides a fully automated binary workflow (combined with the corresponding node_modules location and build of the specific binary file on the target machine).

If the target architecture is known, then binary inlining could certainly be provided though. Most likely forking node-pre-gyp in such specific implementation work would be the best way to achieve this.

(note the reason this external approach works is because the previous asset relocation work overrides the webpack require to fall back to the build-time require).