### PR TITLE
Sourcemaps support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ require('@zeit/ncc')('/path/to/input', {
   minify: true, // default
   // externals to leave as requires of the build
   externals: ["externalpackage"],
-  sourcemap: true // default
+  sourceMap: true // default
 }).then(({ code, assets }) => {
   console.log(code);
   // assets is an object of asset file names to sources

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ $ ncc build input.js -o dist
 Outputs the build of `input.js` into `dist/index.js`.
 
 ```bash
-$ ncc run input.js --source-map
+$ ncc run input.js
 ```
 
 Build to a temporary folder and run the built JS file through Node.js, with source maps support for debugging.
@@ -42,7 +42,8 @@ Build to a temporary folder and run the built JS file through Node.js, with sour
 require('@zeit/ncc')('/path/to/input', {
   minify: true, // default
   // externals to leave as requires of the build
-  externals: ["externalpackage"] 
+  externals: ["externalpackage"],
+  sourcemap: true // default
 }).then(({ code, assets }) => {
   console.log(code);
   // assets is an object of asset file names to sources

--- a/readme.md
+++ b/readme.md
@@ -28,10 +28,10 @@ $ ncc build input.js -o dist
 Outputs the build of `input.js` into `dist/index.js`.
 
 ```bash
-$ ncc run input.js
+$ ncc run input.js --source-map
 ```
 
-Build to a temporary folder and run the executable.
+Build to a temporary folder and run the executable, with source maps for debugging.
 
 ### Node.js
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,13 +20,16 @@ async function main() {
 
   const { code: assetRelocator, assets: assetRelocatorAssets } = await ncc(__dirname + "/../src/asset-relocator");
 
-  if (Object.keys(cliAssets).length || Object.keys(indexAssets).length || Object.keys(assetRelocatorAssets).length) {
+  const { code: sourcemapSupport, assets: sourcemapAssets } = await ncc(require.resolve("source-map-support/register"));
+
+  if (Object.keys(cliAssets).length || Object.keys(indexAssets).length || Object.keys(assetRelocatorAssets).length || Object.keys(sourcemapAssets).length) {
     console.error('Assets emitted by core build, these need to be written into the dist directory');
   }
 
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli);
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);
   writeFileSync(__dirname + "/../dist/ncc/asset-relocator.js", assetRelocator);
+  writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js", sourcemapSupport);
 
   // copy webpack buildin
   await copy(

--- a/src/cli.js
+++ b/src/cli.js
@@ -109,7 +109,7 @@ switch (args._[0]) {
     const ncc = require("./index.js")(eval("require.resolve")(resolve(args._[1] || ".")), {
       minify: !args["--no-minify"],
       externals: args["--external"],
-      sourcemap: !args["--no-source-map"]
+      sourceMap: !args["--no-source-map"]
     });
     ncc.then(({ code, map, assets }) => {
       outDir = outDir || resolve("dist");

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ Commands:
 Options:
   -o, --out [file]      Output directory for build (defaults to dist)
   -M, --no-minify       Skip output minification
-  -s, --source-map      Output the source map for debugging
+  -S, --no-source-map   Skip source map output
   -e, --external [mod]  Skip bundling 'mod'. Can be used many times
   -q, --quiet           Disable build summaries / non-error outputs
 `;
@@ -25,8 +25,8 @@ try {
     "-o": "--out",
     "--no-minify": Boolean,
     "-M": "--no-minify",
-    "--source-map": Boolean,
-    "-s": "--source-map",
+    "--no-source-map": Boolean,
+    "-S": "--no-source-map",
     "--quiet": Boolean,
     "-q": "--quiet"
   });
@@ -109,7 +109,7 @@ switch (args._[0]) {
     const ncc = require("./index.js")(eval("require.resolve")(resolve(args._[1] || ".")), {
       minify: !args["--no-minify"],
       externals: args["--external"],
-      sourcemap: args["--source-map"]
+      sourcemap: !args["--no-source-map"]
     });
     ncc.then(({ code, map, assets }) => {
       outDir = outDir || resolve("dist");

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ Commands:
 Options:
   -o, --out [file]      Output directory for build (defaults to dist)
   -M, --no-minify       Skip output minification
+  -s, --source-map      Output the source map for debugging
   -e, --external [mod]  Skip bundling 'mod'. Can be used many times
   -q, --quiet           Disable build summaries / non-error outputs
 `;
@@ -24,6 +25,8 @@ try {
     "-o": "--out",
     "--no-minify": Boolean,
     M: "--no-minify",
+    "--source-map": Boolean,
+    "-s": "--source-map",
     "--quiet": Boolean,
     "-q": "--quiet"
   });
@@ -36,7 +39,7 @@ catch (e) {
 }
 
 function renderSummary (code, assets, outDir, buildTime) {
-  if (!outDir.endsWith(sep))
+  if (outDir && !outDir.endsWith(sep))
     outDir += sep;
   const codeSize = Math.round(Buffer.byteLength(code, 'utf8') / 1024);
   const assetSizes = Object.create(null);
@@ -105,15 +108,19 @@ switch (args._[0]) {
     const startTime = Date.now();
     const ncc = require("./index.js")(eval("require.resolve")(resolve(args._[1] || ".")), {
       minify: !args["--no-minify"],
-      externals: args["--external"]
+      externals: args["--external"],
+      sourcemap: args["--source-map"]
     });
     
-    ncc.then(({ code, assets }) => {
+    ncc.then(({ code, map, assets }) => {
       outDir = outDir || resolve("dist");
       const fs = require("fs");
       const mkdirp = require("mkdirp");
       mkdirp.sync(outDir);
       fs.writeFileSync(outDir + "/index.js", code);
+      if (map)
+        fs.writeFileSync(outDir + "/index.js.map", map);
+
       for (const asset of Object.keys(assets)) {
         mkdirp.sync(dirname(asset));
         fs.writeFileSync(outDir + "/" + asset, assets[asset]);
@@ -123,7 +130,9 @@ switch (args._[0]) {
         console.log(renderSummary(code, assets, run ? '' : relative(process.cwd(), outDir), Date.now() - startTime));
 
       if (run) {
-        const ps = require("child_process").fork(outDir + "/index.js");
+        const ps = require("child_process").fork(outDir + "/index.js", {
+          execArgv: map ? ["-r", resolve(__dirname, "../dist/ncc/sourcemap-register")] : []
+        });
         ps.on("close", () => require("rimraf").sync(outDir));
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ function resolveModule(context, request, callback, forcedExternals = []) {
   });
 }
 
-module.exports = async (entry, { externals = [], minify = true, sourcemap = false, filename = "index.js" } = {}) => {
+module.exports = async (entry, { externals = [], minify = true, sourceMap = false, filename = "index.js" } = {}) => {
   const mfs = new MemoryFS();
   const compiler = webpack({
     entry,
@@ -52,7 +52,7 @@ module.exports = async (entry, { externals = [], minify = true, sourcemap = fals
       nodeEnv: false,
       minimize: false
     },
-    devtool: sourcemap ? "cheap-source-map" : false,
+    devtool: sourceMap ? "cheap-source-map" : false,
     mode: "production",
     target: "node",
     output: {
@@ -134,7 +134,7 @@ module.exports = async (entry, { externals = [], minify = true, sourcemap = fals
       delete assets["index.js"];
       delete assets["index.js.map"];
       const code = mfs.readFileSync("/index.js", "utf8");
-      const map = sourcemap ? mfs.readFileSync("/index.js.map", "utf8") : null;
+      const map = sourceMap ? mfs.readFileSync("/index.js.map", "utf8") : null;
       resolve({
         code,
         map,

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ function resolveModule(context, request, callback, forcedExternals = []) {
     preserveSymlinks: true,
     extensions: SUPPORTED_EXTENSIONS
   };
-
+  
   if (new Set(forcedExternals).has(request)) {
     console.error(`ncc: Skipping bundling "${request}" per config`);
     return callback(null, `commonjs ${request}`);
@@ -44,7 +44,7 @@ function resolveModule(context, request, callback, forcedExternals = []) {
   });
 }
 
-module.exports = async (entry, { externals = [], minify = true, sourceMap = false } = {}) => {
+module.exports = async (entry, { externals = [], minify = true, sourcemap = false, filename = "index.js" } = {}) => {
   const mfs = new MemoryFS();
   const compiler = webpack({
     entry,
@@ -52,12 +52,12 @@ module.exports = async (entry, { externals = [], minify = true, sourceMap = fals
       nodeEnv: false,
       minimize: false
     },
-    devtool: sourceMap ? "cheap-source-map" : false,
+    devtool: sourcemap ? "cheap-source-map" : false,
     mode: "production",
     target: "node",
     output: {
       path: "/",
-      filename: "out.js",
+      filename,
       libraryTarget: "commonjs2"
     },
     resolve: {
@@ -126,10 +126,10 @@ module.exports = async (entry, { externals = [], minify = true, sourceMap = fals
       }
       const assets = Object.create(null);
       getFlatFiles(mfs.data, assets);
-      delete assets["out.js"];
-      delete assets["out.js.map"];
-      const code = mfs.readFileSync("/out.js", "utf8");
-      const map = sourceMap ? mfs.readFileSync("/out.js.map", "utf8") : null;
+      delete assets["index.js"];
+      delete assets["index.js.map"];
+      const code = mfs.readFileSync("/index.js", "utf8");
+      const map = sourcemap ? mfs.readFileSync("/index.js.map", "utf8") : null;
       resolve({
         code,
         map,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,7 +63,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // ignore e.g.: `.json` files
   if (!integrationTest.endsWith(".js")) continue;
   it(`should evaluate ${integrationTest} without errors`, async () => {
-    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourceMap: true });
+    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourcemap: true });
     module.exports = null;
     sourceMapSources[integrationTest] = map;
     // integration tests will load assets relative to __dirname

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,7 +63,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // ignore e.g.: `.json` files
   if (!integrationTest.endsWith(".js")) continue;
   it(`should evaluate ${integrationTest} without errors`, async () => {
-    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourcemap: true });
+    const { code, map, assets } = await ncc(__dirname + "/integration/" + integrationTest, { sourceMap: true });
     module.exports = null;
     sourceMapSources[integrationTest] = map;
     // integration tests will load assets relative to __dirname


### PR DESCRIPTION
This adds a `--source-map` / `-s` flag for generating source maps through the CLI.

In addition, when used with `ncc run`, source maps support is automatically injected into Node with a build of source-map-support/register.

In the API I changed the input option from `sourceMap: true` to `sourcemap: true` as it seemed more consistent. Happy to change this back if anyone disagrees. Also added a `filename` option to the API as the source map needs a filename to reference to.