### PR TITLE
Disable amd detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,10 +70,15 @@ module.exports = async (entry, { externals = [], minify = true, sourceMap = fals
     node: false,
     externals: (...args) => resolveModule(...[...args, externals]),
     module: {
-      rules: [{
-        test: /\.(js|mjs)/,
-        use: [{ loader: __dirname + "/asset-relocator.js" }]
-      }]
+      rules: [
+        {
+          parser: { amd: false }
+        },
+        {
+          test: /\.(js|mjs)/,
+          use: [{ loader: __dirname + "/asset-relocator.js" }]
+        }
+      ]
     },
     plugins: [
       {


### PR DESCRIPTION
This disables Webpack's AMD detection to ensure all sources are just CJS and ESM.

This does fix the bug on strong-globalize but then exposes another - which is exactly #58 as far as I can tell.