### PR TITLE
Add npm installation to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,11 @@ together with all its dependencies, gcc-style.
 
 ## Usage
 
+### Installation
+```bash
+npm i -g @zeit/ncc
+```
+
 ### CLI
 
 ```bash


### PR DESCRIPTION
Let's avoid security issues by declaring which package to install (It's very normal to install `ncc` instead of `@zeit/ncc`