### PR TITLE
When.js failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "twilio": "^3.23.2",
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17",
-    "webpack": "^4.26.0"
+    "webpack": "^4.26.0",
+    "when": "^3.7.8"
   }
 }

--- a/test/integration/when.js
+++ b/test/integration/when.js
@@ -1,0 +1,5 @@
+var when = require('when');
+
+module.exports = () => {
+  var deferred = when.defer();
+};


### PR DESCRIPTION
When defines itself using the wrapper pattern:

```js
(function(define) { 'use strict';
define(function (require) {

	var timed = require('./lib/decorators/timed');
	var array = require('./lib/decorators/array');
	var flow = require('./lib/decorators/flow');
	var fold = require('./lib/decorators/fold');
	var inspect = require('./lib/decorators/inspect');
});
})(typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); });
```

Similarly to https://github.com/zeit/ncc/pull/87 we have the static analysis problem of not knowing that the internal requires are external requires... (although in theory this static analysis is a trivial compiler problem :P).

This seems to be the bug behind "jugglingdb" builds as far as I can tell.