### PR TITLE
Build binary unit test on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "codecov": "codecov",
     "test": "npm run build && jest",
     "test-coverage": "jest --coverage --globals \"{\\\"coverage\\\":true}\" && codecov",
+    "postinstall": "npm run build-test-binary",
     "prepublish": "in-publish && npm test || not-in-publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the issue where the tests can fail if `yarn build-test-binary` hasn't been run.