### PR TITLE
v8cache experimental flag

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,10 +10,13 @@ async function main() {
   const { code: cli, assets: cliAssets } = await ncc(
     __dirname + "/../src/cli",
     {
+      filename: "cli.js",
       externals: ["./index.js"],
-      minify: true
+      minify: true,
+      v8cache: true
     }
   );
+
   const { code: index, assets: indexAssets } = await ncc(
     __dirname + "/../src/index",
     {
@@ -22,36 +25,44 @@ async function main() {
       // bundle, webpack (and therefore ncc) cannot currently bundle
       // chokidar, which is quite convenient
       externals: ["chokidar"],
-      minify: true
+      filename: "index.js",
+      minify: true,
+      v8cache: true
     }
   );
 
   const { code: nodeLoader, assets: nodeLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/node-loader",
-    { minify: true }
+    {
+      filename: "node-loader.js",
+      minify: true,
+      v8cache: true
+    }
   );
 
   const { code: relocateLoader, assets: relocateLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/relocate-loader",
-    { minify: true }
+    { filename: "relocate-loader.js", minify: true, v8cache: true }
   );
 
   const { code: shebangLoader, assets: shebangLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/shebang-loader",
-    { minify: true }
+    { filename: "shebang-loader.js", minify: true, v8cache: true }
   );
 
   const { code: tsLoader, assets: tsLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/ts-loader",
     {
       externals: ["typescript"],
-      minify: true
+      filename: "ts-loader.js",
+      minify: true,
+      v8cache: true
     }
   );
 
   const { code: sourcemapSupport, assets: sourcemapAssets } = await ncc(
     require.resolve("source-map-support/register"),
-    { minfiy: true }
+    { filename: "source-register.js", minfiy: true, v8cache: true }
   );
 
   const { code: typescript, assets: typescriptAssets } = await ncc(
@@ -60,26 +71,37 @@ async function main() {
   );
 
   // detect unexpected asset emissions from core build
-  if (
-    Object.keys(cliAssets).length ||
-    Object.keys(indexAssets).some(asset => !asset.startsWith('locales/')) ||
-    Object.keys(nodeLoaderAssets).length ||
-    Object.keys(relocateLoaderAssets).length ||
-    Object.keys(shebangLoaderAssets).length ||
-    Object.keys(tsLoaderAssets).length ||
-    Object.keys(sourcemapAssets).length ||
-    Object.keys(typescriptAssets).some(asset => !asset.startsWith('lib/'))
-  ) {
-    console.log(Object.keys(cliAssets));
-    console.log(Object.keys(indexAssets).filter(asset => !asset.startsWith('locales/')));
-    console.log(Object.keys(nodeLoaderAssets));
-    console.log(Object.keys(relocateLoaderAssets));
-    console.log(Object.keys(shebangLoaderAssets));
-    console.log(Object.keys(tsLoaderAssets));
-    console.log(Object.keys(sourcemapAssets));
-    console.log(Object.keys(typescriptAssets).filter(asset => !asset.startsWith('lib/')));
+  const unknownAssets = [
+    ...Object.keys(cliAssets),
+    ...Object.keys(indexAssets).filter(asset => !asset.startsWith('locales/')),
+    ...Object.keys(nodeLoaderAssets),
+    ...Object.keys(relocateLoaderAssets),
+    ...Object.keys(shebangLoaderAssets),
+    ...Object.keys(tsLoaderAssets).filter(asset => !asset.startsWith('lib/')),
+    ...Object.keys(sourcemapAssets),
+    ...Object.keys(typescriptAssets).filter(asset => !asset.startsWith('lib/'))
+  ].filter(asset => !asset.endsWith('.js.cache') && !asset.endsWith('.cache.js'));
+  
+  if (unknownAssets.length) {
     console.error("New assets are being emitted by the core build");
+    console.log(unknownAssets);
   }
+
+  writeFileSync(__dirname + "/../dist/ncc/cli.js.cache", cliAssets["cli.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/index.js.cache", indexAssets["index.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js.cache", sourcemapAssets["sourcemap-register.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/node-loader.js.cache", nodeLoaderAssets["node-loader.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js.cache", relocateLoaderAssets["relocate-loader.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js.cache", shebangLoaderAssets["shebang-loader.js.cache"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js.cache", tsLoaderAssets["ts-loader.js.cache"]);
+
+  writeFileSync(__dirname + "/../dist/ncc/cli.js.cache.js", cliAssets["cli.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/index.js.cache.js", indexAssets["index.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js.cache.js", sourcemapAssets["sourcemap-register.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/node-loader.js.cache.js", nodeLoaderAssets["node-loader.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js.cache.js", relocateLoaderAssets["relocate-loader.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js.cache.js", shebangLoaderAssets["shebang-loader.js.cache.js"]);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js.cache.js", tsLoaderAssets["ts-loader.js.cache.js"]);
 
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli);
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,6 +23,7 @@ Options:
   -e, --external [mod]  Skip bundling 'mod'. Can be used many times
   -q, --quiet           Disable build summaries / non-error outputs
   -w, --watch           Start a watched build
+  --v8-cache            Emit a build using the v8 compile cache
 `;
 
 let args;
@@ -42,7 +43,8 @@ try {
     "--quiet": Boolean,
     "-q": "--quiet",
     "--watch": Boolean,
-    "-w": "--watch"
+    "-w": "--watch",
+    "--v8-cache": Boolean
   });
 } catch (e) {
   if (e.message.indexOf("Unknown or unexpected option") === -1) throw e;
@@ -173,7 +175,8 @@ switch (args._[0]) {
         externals: args["--external"],
         sourceMap: args["--source-map"] || run,
         cache: args["--no-cache"] ? false : undefined,
-        watch: args["--watch"]
+        watch: args["--watch"],
+        v8cache: args["--v8-cache"]
       }
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -279,8 +279,8 @@ module.exports = (
     getFlatFiles(mfs.data, assets, assetState.assetPermissions);
     delete assets[filename];
     delete assets[filename + ".map"];
-    let code = mfs.readFileSync("/" + filename, "utf8");
-    let map = sourceMap ? mfs.readFileSync("/" + filename + ".map", "utf8") : null;
+    let code = mfs.readFileSync(`/${filename}`, "utf8");
+    let map = sourceMap ? mfs.readFileSync(`/${filename}.map`, "utf8") : null;
 
     if (minify) {
       const result = terser.minify(code, {
@@ -309,7 +309,7 @@ module.exports = (
         assets[filename + '.map'] = map;
       code = `const { readFileSync } = require('fs'), { Script } = require('vm');\n` +
           `const source = readFileSync(__dirname + '/${filename}.cache.js').toString(), cachedData = readFileSync(__dirname + '/${filename}.cache');\n` +
-          `new Script(source, { cachedData }).runInNewContext(Object.assign({}, global, { module, exports, require, __filename, __dirname }));\n`;
+          `new Script(source, { cachedData }).runInNewContext(Object.assign({}, global, { console, module, exports, require, __filename, __dirname }));\n`;
       if (map) map = {};
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -307,10 +307,9 @@ module.exports = (
       assets[filename + '.cache.js'] = code;
       if (map)
         assets[filename + '.map'] = map;
-      code = `const { readFileSync } = require('fs'), { Script } = require('vm');\n` +
+      code = `const { readFileSync } = require('fs'), { Script } = require('vm'), { wrap } = require('module');\n` +
           `const source = readFileSync(__dirname + '/${filename}.cache.js').toString(), cachedData = readFileSync(__dirname + '/${filename}.cache');\n` +
-          `Object.assign(global, { module, exports, require, __filename, __dirname });\n` +
-          `new Script(source, { cachedData }).runInThisContext();\n`;
+          `(new Script(wrap(source), { cachedData }).runInThisContext())(exports, require, module, __filename, __dirname);\n`;
       if (map) map = {};
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,8 @@ module.exports = (
         assets[filename + '.map'] = map;
       code = `const { readFileSync } = require('fs'), { Script } = require('vm');\n` +
           `const source = readFileSync(__dirname + '/${filename}.cache.js').toString(), cachedData = readFileSync(__dirname + '/${filename}.cache');\n` +
-          `new Script(source, { cachedData }).runInNewContext(Object.assign({}, global, { console, module, exports, require, __filename, __dirname }));\n`;
+          `Object.assign(global, { module, exports, require, __filename, __dirname });\n` +
+          `new Script(source, { cachedData }).runInThisContext();\n`;
       if (map) map = {};
     }
 

--- a/src/loaders/relocate-loader.js
+++ b/src/loaders/relocate-loader.js
@@ -88,7 +88,7 @@ module.exports = function (code) {
     const name = assetState.assets[assetPath] ||
         (assetState.assets[assetPath] = getUniqueAssetName(outName, assetPath, assetState.assetNames));
 
-    console.log('Emitting ' + assetPath + ' for module ' + id);
+    // console.log('Emitting ' + assetPath + ' for module ' + id);
     assetEmissionPromises = assetEmissionPromises.then(async () => {
       const [source, permissions] = await Promise.all([
         new Promise((resolve, reject) =>

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -43,20 +43,16 @@ module.exports =
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(563);
+var _module_1 = __webpack_require__(816);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 563:
-/***/ (function(__unusedmodule, exports) {
+/***/ 816:
+/***/ (function(module) {
 
-"use strict";
-
-exports.__esModule = true;
-exports["default"] = {};
-
+module.exports = require("@module");
 
 /***/ })
 

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -43,20 +43,16 @@ module.exports =
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(637);
+var _module_1 = __webpack_require__(816);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 637:
-/***/ (function(__unusedmodule, exports) {
+/***/ 816:
+/***/ (function(module) {
 
-"use strict";
-
-exports.__esModule = true;
-exports["default"] = {};
-
+module.exports = require("@module");
 
 /***/ })
 


### PR DESCRIPTION
Fixes #51.

Usage is `ncc build x.js --v8-cache` or the `v8cache: true` option for the API.