### PR TITLE
Fix directory asset emission bug

### DIFF
--- a/src/loaders/relocate-loader.js
+++ b/src/loaders/relocate-loader.js
@@ -558,7 +558,6 @@ module.exports = function (code) {
             transformed = true;
             magicString.overwrite(staticChildNode.start, staticChildNode.end, replacement);
           }
-          staticChildNode = staticChildValue = undefined;
         }
         else if (stats && stats.isDirectory() &&
             // dont emit __dirname or package base
@@ -569,8 +568,8 @@ module.exports = function (code) {
             transformed = true;
             magicString.overwrite(staticChildNode.start, staticChildNode.end, replacement);
           }
-          staticChildNode = staticChildValue = undefined;
         }
+        staticChildNode = staticChildValue = undefined;
       }
     }
   });


### PR DESCRIPTION
This moves (1) from https://github.com/zeit/ncc/pull/117 so that it can be landed sooner as it is an important bug to fix.

The test in #117 will properly catch this when that is merged.