### PR TITLE
Recommend moduleResolution: “node” for Typescript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,8 @@ file is necessary. Most likely you want to indicate `es2015` support:
 ```json
 {
   "compilerOptions": {
-    "target": "es2015"
+    "target": "es2015",
+    "moduleResolution": "node"
   }
 }
 ```


### PR DESCRIPTION
Typescript will by default use it's "classic" module resolution, which is different from Node's

This mostly affects typechecking, but since `ncc` targets node this would make sense.