### PR TITLE
Disable ts-loader typescript warning

### DIFF
--- a/src/loaders/ts-loader.js
+++ b/src/loaders/ts-loader.js
@@ -6,8 +6,15 @@ const { getOptions } = require("loader-utils");
 const loader = require("ts-loader");
 const tsId = require.resolve("typescript");
 module.exports = function () {
+  let first = true;
   const options = getOptions(this);
   if (!options.compiler)
-    options.compiler = tsId;
+    Object.defineProperty(options, 'compiler', {
+      get () {
+        // hack to disable the warning when "compiler !== 'typescript'" while
+        // still supporting numeric id on first access for require call
+        return first ? (first = false, tsId) : 'typescript';
+      }
+    });
   return loader.apply(this, arguments);
 };


### PR DESCRIPTION
No comment on the approach :P The code path being handled is https://github.com/TypeStrong/ts-loader/blob/35b9a5bbf298b5ea4e5b32057dbf252337b9fd08/src/compilerSetup.ts#L30 where the first access is the numeric webpack id.

I do think that the better approach would be to tackle the dynamic require problem head-on with a browserify-like context so that we wouldn't need something like this.