### PR TITLE
Webpack next per-source minification

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -36,6 +36,10 @@ async function main() {
     __dirname + "/../src/loaders/shebang-loader"
   );
 
+  const { code: terserLoader, assets: terserLoaderAssets } = await ncc(
+    __dirname + "/../src/loaders/terser-loader"
+  );
+
   const { code: tsLoader, assets: tsLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/ts-loader"
   );
@@ -51,6 +55,7 @@ async function main() {
     Object.keys(nodeLoaderAssets).length ||
     Object.keys(relocateLoaderAssets).length ||
     Object.keys(shebangLoaderAssets).length ||
+    Object.keys(terserLoaderAssets).length ||
     Object.keys(tsLoaderAssets).some(asset => !asset.startsWith('lib/')) ||
     Object.keys(sourcemapAssets).length
   ) {
@@ -63,6 +68,7 @@ async function main() {
   writeFileSync(__dirname + "/../dist/ncc/loaders/node-loader.js", nodeLoader);
   writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js", relocateLoader);
   writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js", shebangLoader);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/terser-loader.js", terserLoader);  
   writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js", tsLoader);
 
   // copy typescript types

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,10 @@ module.exports = async (
         },
         {
           test: /\.(js|mjs|tsx?)$/,
-          use: [{
+          use: [...minify ? [{
+            loader: __dirname + "/loaders/terser-loader.js",
+            options: { sourceMap }
+          }] : [], {
             loader: __dirname + "/loaders/relocate-loader.js",
             options: { assetNames, assets }
           }]
@@ -131,15 +134,8 @@ module.exports = async (
                 outDir: '//'
               }
             }
-        },
-        {
-        ...minify ? [{
-          test: /\.(js|mjs)$/,
-          use: [{
-            loader: __dirname + "/loaders/terser-loader.js",
-            options: { sourceMap }
           }]
-        }] : []
+        }
       ]
     },
     plugins: [

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,12 @@ module.exports = async (
                 outDir: '//'
               }
             }
+        },
+        {
+          test: /\.(js|mjs)$/,
+          use: [{
+            loader: __dirname + "/loaders/terser-loader.js",
+            options: { sourceMap }
           }]
         }
       ]
@@ -237,27 +243,6 @@ module.exports = async (
       });
     });
   })
-  .then(({ code, map, assets }) => {
-    if (!minify)
-      return { code, map, assets };
-    const result = terser.minify(code, {
-      compress: false,
-      mangle: {
-        keep_classnames: true,
-        keep_fnames: true
-      },
-      sourceMap: sourceMap ? {
-        content: map,
-        filename,
-        url: filename + ".map"
-      } : false
-    });
-    // For some reason, auth0 returns "undefined"!
-    // custom terser phase used over Webpack integration for this reason
-    if (result.code === undefined)
-      return { code, map, assets };
-    return { code: result.code, map: result.map, assets };
-  })
   .then(({ code, map, assets}) => {
     if (!shebangMatch)
       return { code, map, assets };
@@ -266,7 +251,7 @@ module.exports = async (
     if (map)
       map.mappings = ";" + map.mappings;
     return { code, map, assets };
-  })
+  });
 };
 
 // this could be rewritten with actual FS apis / globs, but this is simpler

--- a/src/index.js
+++ b/src/index.js
@@ -133,12 +133,13 @@ module.exports = async (
             }
         },
         {
+        ...minify ? [{
           test: /\.(js|mjs)$/,
           use: [{
             loader: __dirname + "/loaders/terser-loader.js",
             options: { sourceMap }
           }]
-        }
+        }] : []
       ]
     },
     plugins: [

--- a/src/loaders/terser-loader.js
+++ b/src/loaders/terser-loader.js
@@ -1,0 +1,21 @@
+const terser = require("terser");
+const { getOptions } = require('loader-utils');
+
+module.exports = function (code) {
+  const options = getOptions(this);
+  const result = terser.minify(code, {
+    compress: {
+      keep_classnames: true,
+      keep_fnames: true
+    },
+    mangle: {
+      keep_classnames: true,
+      keep_fnames: true
+    },
+    sourceMap: options.sourceMap
+  });
+  // For some reason, auth0 returns "undefined"!
+  if (result.code === undefined)
+    return this.callback(null, code);
+  return this.callback(null, result.code, result.map);
+};

--- a/src/loaders/terser-loader.js
+++ b/src/loaders/terser-loader.js
@@ -2,12 +2,11 @@ const terser = require("terser");
 const { getOptions } = require('loader-utils');
 
 module.exports = function (code) {
+  if (this.cacheable)
+    this.cacheable();
   const options = getOptions(this);
   const result = terser.minify(code, {
-    compress: {
-      keep_classnames: true,
-      keep_fnames: true
-    },
+    compress: false,
     mangle: {
       keep_classnames: true,
       keep_fnames: true


### PR DESCRIPTION
This implements #115 on top of #162, handling minification per-source, and therefore also caching minification per source.

The previous results it turns out were actually without minification due to #168. Here are the numbers with minification:

The build time summary of the self build here is:
* With cache, with minification before this PR: First build 64s, Subsequent builds 47s
* With cache, with minification after this PR: First build 64s, Subsequent builds 36s

