### PR TITLE
Disable minification

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,14 +66,14 @@ file is necessary. Most likely you want to indicate `es2015` support:
 
 ```js
 require('@zeit/ncc')('/path/to/input', {
-  // provide a custom cache path or disable caching
-  cache: "./custom/cache/path" | false,
   // externals to leave as requires of the build
   externals: ["externalpackage"],
   minify: false, // default
-  sourceMap: false, // default
+  sourceMap: false // default
+  // provide a custom cache path or disable caching
+  cache: "./custom/cache/path" | false,
   watch: false // default
-}).then(({ code, map, assets }) => {
+}).then(({ code, assets }) => {
   console.log(code);
   // assets is an object of asset file names to sources
   // expected relative to the output code (if any)

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,10 +17,10 @@ Commands:
 
 Options:
   -o, --out [file]      Output directory for build (defaults to dist)
-  -m, --minify          Minify output
-  -C, --no-cache        Skip build cache population
-  -s, --source-map      Generate source map
   -e, --external [mod]  Skip bundling 'mod'. Can be used many times
+  -C, --no-cache        Skip build cache population
+  -m, --minify          Minify output
+  -s, --source-map      Generate source map
   -q, --quiet           Disable build summaries / non-error outputs
   -q, --watch           Start a watched build
 `;


### PR DESCRIPTION
This disables minification by default, significantly improving build times.

Instead the `--minify` and `--sourceMap` flags are now opt-in.

The self-build still retains minification.