### PR TITLE
Rework externals for perf

### DIFF
--- a/src/utils/get-package-base.js
+++ b/src/utils/get-package-base.js
@@ -1,6 +1,6 @@
 // returns the base-level package folder based on detecting "node_modules"
 // package name boundaries
-const pkgNameRegEx = /(@[^\\\/]+[\\\/])?[^\\\/]+/;
+const pkgNameRegEx = /^(@[^\\\/]+[\\\/])?[^\\\/]+/;
 module.exports = function (id) {
   const pkgIndex = id.lastIndexOf('node_modules');
   if (pkgIndex !== -1 &&
@@ -11,3 +11,5 @@ module.exports = function (id) {
       return id.substr(0, pkgIndex + 13 + pkgNameMatch[0].length);
   }
 };
+
+module.exports.pkgNameRegEx = pkgNameRegEx;


### PR DESCRIPTION
It turns out one of the expensive parts of the build was this function (easy to see by just commenting out the externals and comparing build speeds).

This reimplements the same logic using some custom optimizations.

The other thing implemented here is to move the `.ts` and `.tsx` checks in the resolver to the end. This does mean that `test.js` will take precedence over `test.ts`, but the benefit is that the Webpack resolver doesn't have to stat every single that is ever required in the tree as its `.ts` variation first (which it was doing for EVERYTHING in node_modules...)

Combined these shave about 5 seconds off a 40 second build for me.