### PR TITLE
Write assets with exec permissions

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -200,7 +200,7 @@ switch (args._[0]) {
       for (const asset of Object.keys(assets)) {
         const assetPath = outDir + "/" + asset;
         mkdirp.sync(dirname(assetPath));
-        fs.writeFileSync(assetPath, assets[asset]);
+        fs.writeFileSync(assetPath, assets[asset], { mode: 0o777 });
       }
 
       if (!args["--quiet"]) {


### PR DESCRIPTION
Fixes #172.
Fixes #198

This writes all assets with exec permissions, if we had a list of extensions to handle here we could do that too, but I wasn't sure what an exhaustive list would like like.