### PR TITLE
Disable ts-loader typechecking for non-build files (resolves #208)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ module.exports = (
           use: [{
             loader: __dirname + "/loaders/ts-loader.js",
             options: {
+              transpileOnly: true,
               compilerOptions: {
                 outDir: '//'
               }


### PR DESCRIPTION
Up until now the ts loader has been running in the mode where it runs all typechecking (like what you get in the VScode console for all the types in the project). Because this feature doesn't naturally support webpack caching, disabling it is the easiest fix for #208.

I tend to think a more permissive build makes sense as well and I believe is in line with what Deno offers too.

The main concern with an alternative fix like @sokra describes is that it would mean always loading the ts loader upfront (therefore slowing down startup) unless we can get a hook into the cache usage to know if a ".ts" file is being loaded or not in order to conditionally do this (perhaps Tobias will know if this is possible).

But it seems easier and a better experience I think to just go for the one-liner :)