### PR TITLE
Output asset permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ require('@zeit/ncc')('/path/to/input', {
   watch: false // default
 }).then(({ code, map, assets }) => {
   console.log(code);
-  // assets is an object of asset file names to sources
+  // assets is an object of asset file names to { source, permissions }
   // expected relative to the output code (if any)
 })
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -57,7 +57,7 @@ function renderSummary(code, assets, outDir, buildTime) {
   let totalSize = codeSize;
   let maxAssetNameLength = 8; // "index.js".length
   for (const asset of Object.keys(assets)) {
-    const assetSource = assets[asset];
+    const assetSource = assets[asset].source;
     const assetSize = Math.round(
       (assetSource.byteLength || Buffer.byteLength(assetSource, "utf8")) / 1024
     );
@@ -200,7 +200,7 @@ switch (args._[0]) {
       for (const asset of Object.keys(assets)) {
         const assetPath = outDir + "/" + asset;
         mkdirp.sync(dirname(assetPath));
-        fs.writeFileSync(assetPath, assets[asset]);
+        fs.writeFileSync(assetPath, assets[asset].source, { mode: assets[asset].permissions });
       }
 
       if (!args["--quiet"]) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ const hashOf = name => {
 		.slice(0, 10);
 }
 
-const nodeLoader = require(__dirname + "/loaders/node-loader.js");
-const relocateLoader = require(__dirname + "/loaders/relocate-loader.js");
+const nodeLoader = eval('require(__dirname + "/loaders/node-loader.js")');
+const relocateLoader = eval('require(__dirname + "/loaders/relocate-loader.js")');
 
 module.exports = (
   entry,

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const shebangRegEx = require('./utils/shebang');
 const { pkgNameRegEx } = require("./utils/get-package-base");
 const nccCacheDir = require("./utils/ncc-cache-dir");
-const FileCachePlugin = require("webpack/lib/cache/FileCachePlugin");
 
 const nodeBuiltins = new Set([...require("repl")._builtinLibs, "constants", "module", "timers", "console", "_stream_writable", "_stream_readable", "_stream_duplex"]);
 
@@ -24,6 +23,9 @@ const hashOf = name => {
 		.slice(0, 10);
 }
 
+const nodeLoader = require(__dirname + "/loaders/node-loader.js");
+const relocateLoader = require(__dirname + "/loaders/relocate-loader.js");
+
 module.exports = (
   entry,
   {
@@ -35,12 +37,18 @@ module.exports = (
     watch = false
   } = {}
 ) => {
-  const shebangMatch = fs.readFileSync(resolve.sync(entry)).toString().match(shebangRegEx);
+  const resolvedEntry = resolve.sync(entry);
+  const shebangMatch = fs.readFileSync(resolvedEntry).toString().match(shebangRegEx);
   const mfs = new MemoryFS();
-  const assetNames = Object.create(null);
-  const assets = Object.create(null);
   const resolvePlugins = [];
   let tsconfigMatchPath;
+  const assetState = {
+    assets: Object.create(null),
+    assetNames: Object.create(null),
+    assetPermissions: undefined
+  };
+  nodeLoader.setAssetState(assetState);
+  relocateLoader.setAssetState(assetState);
   // add TsconfigPathsPlugin to support `paths` resolution in tsconfig
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory
@@ -115,15 +123,13 @@ module.exports = (
         {
           test: /\.node$/,
           use: [{
-            loader: __dirname + "/loaders/node-loader.js",
-            options: { assetNames, assets }
+            loader: __dirname + "/loaders/node-loader.js"
           }]
         },
         {
           test: /\.(js|mjs|tsx?)$/,
           use: [{
             loader: __dirname + "/loaders/relocate-loader.js",
-            options: { assetNames, assets }
           }]
         },
         {
@@ -149,12 +155,22 @@ module.exports = (
     plugins: [
       {
         apply(compiler) {
+          /* compiler.hooks.afterCompile.tap("ncc", compilation => {
+            compilation.cache.store('/NccPlugin/' + resolvedEntry, null, JSON.stringify(assetState.assetPermissions.permissions), (err) => {
+              if (err) console.error(err);
+            });
+          }); */
           compiler.hooks.watchRun.tap("ncc", () => {
             if (rebuildHandler)
               rebuildHandler();
           });
           // override "not found" context to try built require first
           compiler.hooks.compilation.tap("ncc", compilation => {
+            assetState.assetPermissions = Object.create(null);
+            /* compilation.cache.get('/NccPlugin/' + resolvedEntry, null, (err, _assetPermissions) => {
+              if (err) console.error(err);
+              assetState.assetPermissions = JSON.parse(_assetPermissions || 'null') || Object.create(null);
+            }); */
             // hack to ensure __webpack_require__ is added to empty context wrapper
             compilation.hooks.additionalModuleRuntimeRequirements.tap("ncc", (module, runtimeRequirements) => {
               if(module._contextDependencies)
@@ -272,7 +288,7 @@ module.exports = (
 
   function finalizeHandler () {
     const assets = Object.create(null);
-    getFlatFiles(mfs.data, assets);
+    getFlatFiles(mfs.data, assets, assetState.assetPermissions);
     delete assets[filename];
     delete assets[filename + ".map"];
     let code = mfs.readFileSync("/index.js", "utf8");
@@ -309,13 +325,18 @@ module.exports = (
 };
 
 // this could be rewritten with actual FS apis / globs, but this is simpler
-function getFlatFiles(mfsData, output, curBase = "") {
+function getFlatFiles(mfsData, output, assetPermissions, curBase = "") {
   for (const path of Object.keys(mfsData)) {
     const item = mfsData[path];
     const curPath = curBase + "/" + path;
     // directory
-    if (item[""] === true) getFlatFiles(item, output, curPath);
+    if (item[""] === true) getFlatFiles(item, output, assetPermissions, curPath);
     // file
-    else if (!curPath.endsWith("/")) output[curPath.substr(1)] = mfsData[path];
+    else if (!curPath.endsWith("/")) {
+      output[curPath.substr(1)] = {
+        source: mfsData[path],
+        permissions: assetPermissions[curPath.substr(1)]
+      }
+    }
   }
 }

--- a/src/loaders/node-loader.js
+++ b/src/loaders/node-loader.js
@@ -1,8 +1,8 @@
 const path = require('path');
-const { getOptions } = require('loader-utils');
 const getUniqueAssetName = require('../utils/dedupe-names');
 const sharedlibEmit = require('../utils/sharedlib-emit');
 const getPackageBase = require('../utils/get-package-base');
+const fs = require('fs');
 
 module.exports = async function (content) {
   if (this.cacheable)
@@ -10,14 +10,22 @@ module.exports = async function (content) {
   this.async();
 
   const id = this.resourcePath;
-  const options = getOptions(this);
 
   const pkgBase = getPackageBase(this.resourcePath) || path.dirname(id);
-  await sharedlibEmit(pkgBase, this.emitFile);
+  await sharedlibEmit(pkgBase, assetState, this.emitFile);
 
-  const name = getUniqueAssetName(id.substr(pkgBase.length + 1), id, options.assetNames);
+  const name = getUniqueAssetName(id.substr(pkgBase.length + 1), id, assetState.assetNames);
+  
+  const permissions = await new Promise((resolve, reject) => 
+    fs.stat(id, (err, stats) => err ? reject(err) : resolve(stats.mode))
+  )
+  assetState.assetPermissions[name] = permissions;
   this.emitFile(name, content);
 
   this.callback(null, 'module.exports = __non_webpack_require__("./' + name + '")');
 };
 module.exports.raw = true;
+let assetState;
+module.exports.setAssetState = function (state) {
+  assetState = state;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,7 +23,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
         // very simple asset validation in unit tests
         if (unitTest.startsWith("asset-")) {
           expect(Object.keys(assets).length).toBeGreaterThan(0);
-          expect(assets[Object.keys(assets)[0]] instanceof Buffer);
+          expect(assets[Object.keys(assets)[0].source] instanceof Buffer);
         }
         const actual = code
           .trim()
@@ -78,7 +78,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
     for (const asset of Object.keys(assets)) {
       const assetPath = tmpDir + asset;
       mkdirp.sync(dirname(assetPath));
-      fs.writeFileSync(assetPath, assets[asset]);
+      fs.writeFileSync(assetPath, assets[asset].source);
     }
     fs.writeFileSync(tmpDir + "index.js", code);
     fs.writeFileSync(tmpDir + "index.js.map", map);

--- a/test/unit/amd-disable/output-coverage.js
+++ b/test/unit/amd-disable/output-coverage.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(901);
+/******/ 	return __webpack_require__(549);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 901:
+/***/ 549:
 /***/ (function() {
 
 if (typeof define === 'function' && define.amd)

--- a/test/unit/amd-disable/output.js
+++ b/test/unit/amd-disable/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(947);
+/******/ 	return __webpack_require__(549);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 947:
+/***/ 549:
 /***/ (function() {
 
 if (typeof define === 'function' && define.amd)

--- a/test/unit/amd-disable/output.js
+++ b/test/unit/amd-disable/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(549);
+/******/ 	return __webpack_require__(819);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 549:
+/***/ 819:
 /***/ (function() {
 
 if (typeof define === 'function' && define.amd)

--- a/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
@@ -34,7 +34,7 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(954);
+/******/ 	return __webpack_require__(824);
 /******/ })
 /************************************************************************/
 /******/ ({
@@ -53,7 +53,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 954:
+/***/ 824:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/test/unit/asset-fs-inline-path-enc-es-2/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output.js
@@ -34,26 +34,10 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(259);
+/******/ 	return __webpack_require__(824);
 /******/ })
 /************************************************************************/
 /******/ ({
-
-/***/ 259:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
-
-
-
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -66,6 +50,22 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 824:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
+
+
+
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
@@ -34,26 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(725);
+/******/ 	return __webpack_require__(426);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 66:
-/***/ (function(module) {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 725:
+/***/ 426:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -66,6 +52,20 @@ __webpack_require__.r(__webpack_exports__);
 
 
 console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+/***/ }),
+
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es-3/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output.js
@@ -34,26 +34,10 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(426);
+/******/ 	return __webpack_require__(833);
 /******/ })
 /************************************************************************/
 /******/ ({
-
-/***/ 426:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
-
-
-
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -66,6 +50,22 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 833:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
+
+
+
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es-3/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output.js
@@ -34,12 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(545);
+/******/ 	return __webpack_require__(426);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 545:
+/***/ 426:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
@@ -34,12 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(260);
+/******/ 	return __webpack_require__(200);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 260:
+/***/ 200:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/test/unit/asset-fs-inline-path-enc-es-4/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output.js
@@ -34,26 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(736);
+/******/ 	return __webpack_require__(200);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 66:
-/***/ (function(module) {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 736:
+/***/ 200:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -68,6 +54,20 @@ __webpack_require__.r(__webpack_exports__);
 const join = path__WEBPACK_IMPORTED_MODULE_1__["join"];
 
 console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+/***/ }),
+
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es-4/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output.js
@@ -34,12 +34,26 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(200);
+/******/ 	return __webpack_require__(992);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 200:
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 992:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -54,20 +68,6 @@ __webpack_require__.r(__webpack_exports__);
 const join = path__WEBPACK_IMPORTED_MODULE_1__["join"];
 
 console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-/***/ }),
-
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 66:
-/***/ (function(module) {
-
-module.exports = require("fs");
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
@@ -34,26 +34,10 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(285);
+/******/ 	return __webpack_require__(963);
 /******/ })
 /************************************************************************/
 /******/ ({
-
-/***/ 285:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
-
-
-
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -66,6 +50,22 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 963:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(66);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(589);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
+
+
+
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output.js
@@ -34,26 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(963);
+/******/ 	return __webpack_require__(437);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 66:
-/***/ (function(module) {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 963:
+/***/ 437:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -66,6 +52,20 @@ __webpack_require__.r(__webpack_exports__);
 
 
 console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+/***/ }),
+
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc-es/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output.js
@@ -34,7 +34,7 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(885);
+/******/ 	return __webpack_require__(963);
 /******/ })
 /************************************************************************/
 /******/ ({
@@ -53,7 +53,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 885:
+/***/ 963:
 /***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/test/unit/asset-fs-inline-path-enc/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc/output-coverage.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(366);
+/******/ 	return __webpack_require__(239);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 366:
+/***/ 239:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);

--- a/test/unit/asset-fs-inline-path-enc/output.js
+++ b/test/unit/asset-fs-inline-path-enc/output.js
@@ -32,10 +32,19 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(660);
+/******/ 	return __webpack_require__(239);
 /******/ })
 /************************************************************************/
 /******/ ({
+
+/***/ 239:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+const { join } = __webpack_require__(589);
+console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -48,15 +57,6 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 660:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-const { join } = __webpack_require__(589);
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-enc/output.js
+++ b/test/unit/asset-fs-inline-path-enc/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(239);
+/******/ 	return __webpack_require__(517);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 239:
+/***/ 517:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);

--- a/test/unit/asset-fs-inline-path-shadow/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-shadow/output-coverage.js
@@ -32,10 +32,25 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(873);
+/******/ 	return __webpack_require__(122);
 /******/ })
 /************************************************************************/
 /******/ ({
+
+/***/ 122:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+const { join } = __webpack_require__(589);
+
+console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+(function () {
+  var join = () => 'nope';
+  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
+})();
+
+/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -48,21 +63,6 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 873:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-const { join } = __webpack_require__(589);
-
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-(function () {
-  var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
-})();
 
 /***/ })
 

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -32,12 +32,19 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(122);
+/******/ 	return __webpack_require__(609);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 122:
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 609:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);
@@ -49,13 +56,6 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
   var join = () => 'nope';
   console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
 })();
-
-/***/ }),
-
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
 
 /***/ }),
 

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -32,10 +32,25 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(711);
+/******/ 	return __webpack_require__(122);
 /******/ })
 /************************************************************************/
 /******/ ({
+
+/***/ 122:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+const { join } = __webpack_require__(589);
+
+console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+
+(function () {
+  var join = () => 'nope';
+  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
+})();
+
+/***/ }),
 
 /***/ 589:
 /***/ (function(module) {
@@ -48,21 +63,6 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 711:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-const { join } = __webpack_require__(589);
-
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-(function () {
-  var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
-})();
 
 /***/ })
 

--- a/test/unit/asset-fs-inlining-multi/output-coverage.js
+++ b/test/unit/asset-fs-inlining-multi/output-coverage.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(918);
+/******/ 	return __webpack_require__(274);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 66:
-/***/ (function(module) {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 918:
+/***/ 274:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);
 console.log(fs.readFileSync(__dirname + '/asset.txt'));
 console.log(fs.readFileSync(__dirname + '/asset1.txt'));
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
 
 /***/ })
 

--- a/test/unit/asset-fs-inlining-multi/output.js
+++ b/test/unit/asset-fs-inlining-multi/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(274);
+/******/ 	return __webpack_require__(715);
 /******/ })
 /************************************************************************/
 /******/ ({
-
-/***/ 274:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-console.log(fs.readFileSync(__dirname + '/asset1.txt'));
-
-/***/ }),
 
 /***/ 66:
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 715:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(__dirname + '/asset.txt'));
+console.log(fs.readFileSync(__dirname + '/asset1.txt'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inlining-multi/output.js
+++ b/test/unit/asset-fs-inlining-multi/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(619);
+/******/ 	return __webpack_require__(274);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 619:
+/***/ 274:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);

--- a/test/unit/asset-fs-inlining/output-coverage.js
+++ b/test/unit/asset-fs-inlining/output-coverage.js
@@ -32,7 +32,7 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(858);
+/******/ 	return __webpack_require__(805);
 /******/ })
 /************************************************************************/
 /******/ ({
@@ -44,7 +44,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 858:
+/***/ 805:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const fs = __webpack_require__(66);

--- a/test/unit/asset-fs-inlining/output.js
+++ b/test/unit/asset-fs-inlining/output.js
@@ -32,23 +32,23 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(477);
+/******/ 	return __webpack_require__(805);
 /******/ })
 /************************************************************************/
 /******/ ({
-
-/***/ 477:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-
-/***/ }),
 
 /***/ 66:
 /***/ (function(module) {
 
 module.exports = require("fs");
+
+/***/ }),
+
+/***/ 805:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(__dirname + '/asset.txt'));
 
 /***/ })
 

--- a/test/unit/asset-fs-inlining/output.js
+++ b/test/unit/asset-fs-inlining/output.js
@@ -32,23 +32,23 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(805);
+/******/ 	return __webpack_require__(157);
 /******/ })
 /************************************************************************/
 /******/ ({
+
+/***/ 157:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(__dirname + '/asset.txt'));
+
+/***/ }),
 
 /***/ 66:
 /***/ (function(module) {
 
 module.exports = require("fs");
-
-/***/ }),
-
-/***/ 805:
-/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
-
-const fs = __webpack_require__(66);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
 
 /***/ })
 

--- a/test/unit/asset-package-json/output-coverage.js
+++ b/test/unit/asset-package-json/output-coverage.js
@@ -32,25 +32,25 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(607);
+/******/ 	return __webpack_require__(202);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 607:
+/***/ 202:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const path = __webpack_require__(589);
 
 var binding_path =
     binary.find(__dirname + '/package.json');
+
+/***/ }),
+
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
 
 /***/ })
 

--- a/test/unit/asset-package-json/output.js
+++ b/test/unit/asset-package-json/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(540);
+/******/ 	return __webpack_require__(202);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 540:
+/***/ 202:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const path = __webpack_require__(589);

--- a/test/unit/asset-package-json/output.js
+++ b/test/unit/asset-package-json/output.js
@@ -32,25 +32,25 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(202);
+/******/ 	return __webpack_require__(959);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 202:
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 959:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 const path = __webpack_require__(589);
 
 var binding_path =
     binary.find(__dirname + '/package.json');
-
-/***/ }),
-
-/***/ 589:
-/***/ (function(module) {
-
-module.exports = require("path");
 
 /***/ })
 

--- a/test/unit/browserify/output-coverage.js
+++ b/test/unit/browserify/output-coverage.js
@@ -32,33 +32,33 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(275);
+/******/ 	return __webpack_require__(756);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 275:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ 509:
+/***/ (function(module) {
 
-var require;var require;(function(f){if(true){module.exports=f()}else { var g; }})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return require(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
-  module.exports = [require("./dep1"), require("./dep2")];
-},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(44) },
-  "./dep2": { exports: __webpack_require__(645) }},[1])(1)
-});
+module.exports = 'dep2';
 
 /***/ }),
 
-/***/ 44:
+/***/ 638:
 /***/ (function(module) {
 
 module.exports = 'dep1';
 
 /***/ }),
 
-/***/ 645:
-/***/ (function(module) {
+/***/ 756:
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-module.exports = 'dep2';
+var require;var require;(function(f){if(true){module.exports=f()}else { var g; }})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return require(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+  module.exports = [require("./dep1"), require("./dep2")];
+},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(638) },
+  "./dep2": { exports: __webpack_require__(509) }},[1])(1)
+});
 
 /***/ })
 

--- a/test/unit/browserify/output.js
+++ b/test/unit/browserify/output.js
@@ -32,33 +32,33 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(241);
+/******/ 	return __webpack_require__(756);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 193:
+/***/ 509:
 /***/ (function(module) {
 
 module.exports = 'dep2';
 
 /***/ }),
 
-/***/ 241:
+/***/ 638:
+/***/ (function(module) {
+
+module.exports = 'dep1';
+
+/***/ }),
+
+/***/ 756:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 var require;var require;(function(f){if(true){module.exports=f()}else { var g; }})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return require(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
   module.exports = [require("./dep1"), require("./dep2")];
-},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(452) },
-  "./dep2": { exports: __webpack_require__(193) }},[1])(1)
+},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(638) },
+  "./dep2": { exports: __webpack_require__(509) }},[1])(1)
 });
-
-/***/ }),
-
-/***/ 452:
-/***/ (function(module) {
-
-module.exports = 'dep1';
 
 /***/ })
 

--- a/test/unit/browserify/output.js
+++ b/test/unit/browserify/output.js
@@ -32,32 +32,32 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(756);
+/******/ 	return __webpack_require__(573);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 509:
-/***/ (function(module) {
-
-module.exports = 'dep2';
-
-/***/ }),
-
-/***/ 638:
+/***/ 187:
 /***/ (function(module) {
 
 module.exports = 'dep1';
 
 /***/ }),
 
-/***/ 756:
+/***/ 252:
+/***/ (function(module) {
+
+module.exports = 'dep2';
+
+/***/ }),
+
+/***/ 573:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 var require;var require;(function(f){if(true){module.exports=f()}else { var g; }})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return require(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
   module.exports = [require("./dep1"), require("./dep2")];
-},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(638) },
-  "./dep2": { exports: __webpack_require__(509) }},[1])(1)
+},{"./dep1": undefined, "./dep2": undefined}]},{"./dep1": { exports: __webpack_require__(187) },
+  "./dep2": { exports: __webpack_require__(252) }},[1])(1)
 });
 
 /***/ })

--- a/test/unit/dirname-len/output-coverage.js
+++ b/test/unit/dirname-len/output-coverage.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(962);
+/******/ 	return __webpack_require__(303);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 962:
+/***/ 303:
 /***/ (function() {
 
 console.log(function (a, b) {

--- a/test/unit/dirname-len/output.js
+++ b/test/unit/dirname-len/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(303);
+/******/ 	return __webpack_require__(32);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 303:
+/***/ 32:
 /***/ (function() {
 
 console.log(function (a, b) {

--- a/test/unit/dirname-len/output.js
+++ b/test/unit/dirname-len/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(533);
+/******/ 	return __webpack_require__(303);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 533:
+/***/ 303:
 /***/ (function() {
 
 console.log(function (a, b) {

--- a/test/unit/require-main/output-coverage.js
+++ b/test/unit/require-main/output-coverage.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(472);
+/******/ 	return __webpack_require__(727);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 472:
+/***/ 727:
 /***/ (function() {
 
 console.log(require.main.filename);

--- a/test/unit/require-main/output.js
+++ b/test/unit/require-main/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(727);
+/******/ 	return __webpack_require__(297);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 727:
+/***/ 297:
 /***/ (function() {
 
 console.log(require.main.filename);

--- a/test/unit/require-main/output.js
+++ b/test/unit/require-main/output.js
@@ -32,12 +32,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(635);
+/******/ 	return __webpack_require__(727);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 635:
+/***/ 727:
 /***/ (function() {
 
 console.log(require.main.filename);

--- a/test/unit/require-resolve-like/output-coverage.js
+++ b/test/unit/require-resolve-like/output-coverage.js
@@ -32,16 +32,16 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(73);
+/******/ 	return __webpack_require__(170);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 73:
+/***/ 170:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 // this should be a self-require not an asset!
-__webpack_require__(73)
+__webpack_require__(170)
 
 /***/ })
 

--- a/test/unit/require-resolve-like/output.js
+++ b/test/unit/require-resolve-like/output.js
@@ -32,16 +32,16 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(170);
+/******/ 	return __webpack_require__(506);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 170:
+/***/ 506:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 // this should be a self-require not an asset!
-__webpack_require__(170)
+__webpack_require__(506)
 
 /***/ })
 

--- a/test/unit/require-resolve-like/output.js
+++ b/test/unit/require-resolve-like/output.js
@@ -32,16 +32,16 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(530);
+/******/ 	return __webpack_require__(170);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 530:
+/***/ 170:
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
 // this should be a self-require not an asset!
-__webpack_require__(530)
+__webpack_require__(170)
 
 /***/ })
 

--- a/test/unit/shebang/output-coverage.js
+++ b/test/unit/shebang/output-coverage.js
@@ -33,12 +33,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(801);
+/******/ 	return __webpack_require__(162);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 801:
+/***/ 162:
 /***/ (function(module) {
 
 module.exports = 'asdf';

--- a/test/unit/shebang/output.js
+++ b/test/unit/shebang/output.js
@@ -33,12 +33,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(809);
+/******/ 	return __webpack_require__(162);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 809:
+/***/ 162:
 /***/ (function(module) {
 
 module.exports = 'asdf';

--- a/test/unit/shebang/output.js
+++ b/test/unit/shebang/output.js
@@ -33,12 +33,12 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(162);
+/******/ 	return __webpack_require__(591);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 162:
+/***/ 591:
 /***/ (function(module) {
 
 module.exports = 'asdf';

--- a/test/unit/ts-decl/output-coverage.js
+++ b/test/unit/ts-decl/output-coverage.js
@@ -34,25 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(279);
+/******/ 	return __webpack_require__(949);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 279:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(282);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
-
-
-
-/***/ }),
-
-/***/ 282:
+/***/ 679:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
@@ -62,6 +49,19 @@ function test(arg) {
     return arg;
 }
 exports.test = test;
+
+
+/***/ }),
+
+/***/ 949:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(679);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
+
 
 
 /***/ })

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -34,12 +34,25 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(949);
+/******/ 	return __webpack_require__(25);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 679:
+/***/ 25:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(781);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
+
+
+
+/***/ }),
+
+/***/ 781:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
@@ -49,19 +62,6 @@ function test(arg) {
     return arg;
 }
 exports.test = test;
-
-
-/***/ }),
-
-/***/ 949:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(679);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
-
 
 
 /***/ })

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -34,25 +34,12 @@ module.exports =
 /******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(256);
+/******/ 	return __webpack_require__(949);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 256:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(381);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
-/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
-
-
-
-/***/ }),
-
-/***/ 381:
+/***/ 679:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
@@ -62,6 +49,19 @@ function test(arg) {
     return arg;
 }
 exports.test = test;
+
+
+/***/ }),
+
+/***/ 949:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(679);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
+
 
 
 /***/ })

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(830);
+/******/ 	return __webpack_require__(278);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 830:
+/***/ 278:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(948);
+var _module_1 = __webpack_require__(725);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 948:
+/***/ 725:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -32,30 +32,30 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(615);
+/******/ 	return __webpack_require__(278);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 61:
+/***/ 278:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var _module_1 = __webpack_require__(725);
+console.log(_module_1["default"]);
+
+
+/***/ }),
+
+/***/ 725:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
 
 exports.__esModule = true;
 exports["default"] = {};
-
-
-/***/ }),
-
-/***/ 615:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-exports.__esModule = true;
-var _module_1 = __webpack_require__(61);
-console.log(_module_1["default"]);
 
 
 /***/ })

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(278);
+/******/ 	return __webpack_require__(398);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 278:
+/***/ 398:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(725);
+var _module_1 = __webpack_require__(649);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 725:
+/***/ 649:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(670);
+/******/ 	return __webpack_require__(657);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 670:
+/***/ 657:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(932);
+var _module_1 = __webpack_require__(898);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 932:
+/***/ 898:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(657);
+/******/ 	return __webpack_require__(308);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 657:
+/***/ 308:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(898);
+var _module_1 = __webpack_require__(341);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 898:
+/***/ 341:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(122);
+/******/ 	return __webpack_require__(657);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 122:
+/***/ 657:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(342);
+var _module_1 = __webpack_require__(898);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 342:
+/***/ 898:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";


### PR DESCRIPTION
This stores the permissions of assets in a side table and ensures the corresponding output asset permissions.

In theory this is a major change as the assets API is changed to be an object of `{ [assetName]: { source, permissions } }` instead of `{ [assetName]: source }` now.

@sokra an interesting thing here was it turned out unnecessary to maintain the cache as for some reason it seems like Webpack isn't actually caching the sources with emitted assets. Ideally these should be cached though I think?

I've left the cache persistence of asset permissions commented out for now given the above.