### PR TITLE
Disable ts caching for typechecking

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 const ncc = require("../src/index.js");
-const { statSync, writeFileSync } = require("fs");
+const { statSync, writeFileSync, readFileSync } = require("fs");
 const { promisify } = require("util");
 const { relative } = require("path");
 const copy = promisify(require("copy"));
@@ -73,6 +73,7 @@ async function main() {
   writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js", relocateLoader);
   writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js", shebangLoader);
   writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js", tsLoader);
+  writeFileSync(__dirname + "/../dist/ncc/loaders/uncacheable.js", readFileSync(__dirname + "/../src/loaders/uncacheable.js"));
 
   // copy typescript types
   await copy(

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,9 @@ module.exports = (
         {
           test: /\.tsx?$/,
           use: [{
+            loader: __dirname + "/loaders/uncacheable.js"
+          }, 
+          {
             loader: __dirname + "/loaders/ts-loader.js",
             options: {
               compilerOptions: {

--- a/src/loaders/uncacheable.js
+++ b/src/loaders/uncacheable.js
@@ -1,0 +1,4 @@
+module.exports = function (input) {
+  this.cacheable(false);
+  return input;
+};

--- a/test/unit/ts-decl/output-coverage.js
+++ b/test/unit/ts-decl/output-coverage.js
@@ -39,7 +39,7 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 679:
+/***/ 138:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
@@ -58,7 +58,7 @@ exports.test = test;
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(679);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(138);
 /* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
 

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -44,7 +44,7 @@ module.exports =
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(781);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(381);
 /* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_test_ts__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _test_ts__WEBPACK_IMPORTED_MODULE_0__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _test_ts__WEBPACK_IMPORTED_MODULE_0__[key]; }) }(__WEBPACK_IMPORT_KEY__));
 
@@ -52,7 +52,7 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
-/***/ 781:
+/***/ 381:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -32,30 +32,30 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(278);
+/******/ 	return __webpack_require__(996);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 278:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-exports.__esModule = true;
-var _module_1 = __webpack_require__(725);
-console.log(_module_1["default"]);
-
-
-/***/ }),
-
-/***/ 725:
+/***/ 271:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
 
 exports.__esModule = true;
 exports["default"] = {};
+
+
+/***/ }),
+
+/***/ 996:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var _module_1 = __webpack_require__(271);
+console.log(_module_1["default"]);
 
 
 /***/ })

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(398);
+/******/ 	return __webpack_require__(468);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 398:
+/***/ 468:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(649);
+var _module_1 = __webpack_require__(742);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 649:
+/***/ 742:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -32,30 +32,30 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(657);
+/******/ 	return __webpack_require__(704);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 657:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-exports.__esModule = true;
-var _module_1 = __webpack_require__(898);
-console.log(_module_1["default"]);
-
-
-/***/ }),
-
-/***/ 898:
+/***/ 455:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
 
 exports.__esModule = true;
 exports["default"] = {};
+
+
+/***/ }),
+
+/***/ 704:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var _module_1 = __webpack_require__(455);
+console.log(_module_1["default"]);
 
 
 /***/ })

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -32,24 +32,24 @@ module.exports =
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(308);
+/******/ 	return __webpack_require__(650);
 /******/ })
 /************************************************************************/
 /******/ ({
 
-/***/ 308:
+/***/ 650:
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(341);
+var _module_1 = __webpack_require__(851);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 341:
+/***/ 851:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";


### PR DESCRIPTION
This is the alternative fix to #210 that retains the typing errors being emitted.

The approach here is to disable caching for ts compilations entirely to ensure that the types of the local files are checked everytime.

To utilize the webpack 5 cache for this work would likely require the ts-loader project to serialize its internal memoizations using the webpack cache api while itself becoming uncacheable. //cc @johnnyreilly