### PR TITLE
ncc run to use sourcemaps by default

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -171,7 +171,7 @@ switch (args._[0]) {
       {
         minify: args["--minify"],
         externals: args["--external"],
-        sourceMap: args["--source-map"] || run && args["--minify"],
+        sourceMap: args["--source-map"] || run,
         cache: args["--no-cache"] ? false : undefined,
         watch: args["--watch"]
       }


### PR DESCRIPTION
I think by default having the good debugging experience makes sense here, as the sourcemaps generation time isn't too long at all.