### PR TITLE
VM2 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "twilio": "^3.23.2",
     "typescript": "^3.2.2",
+    "vm2": "^3.6.6",
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17",
     "webpack": "5.0.0-alpha.0",

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,9 @@ module.exports = (
     assetNames: Object.create(null),
     assetPermissions: undefined
   };
+  assetState.assetNames[filename] = true;
+  if (sourceMap)
+    assetState.assetNames[filename + '.map'] = true;
   nodeLoader.setAssetState(assetState);
   relocateLoader.setAssetState(assetState);
   // add TsconfigPathsPlugin to support `paths` resolution in tsconfig

--- a/src/loaders/relocate-loader.js
+++ b/src/loaders/relocate-loader.js
@@ -290,9 +290,6 @@ module.exports = function (code) {
   const emitAsset = (assetPath) => {
     // JS assets to support require(assetPath) and not fs-based handling
     // NB package.json is ambiguous here...
-    if (assetPath.endsWith('.js') || assetPath.endsWith('.mjs'))
-      return;
-
     let outName = path.basename(assetPath);
 
     if (assetPath.endsWith('.node')) {
@@ -591,6 +588,11 @@ module.exports = function (code) {
                node.property.name === 'main' &&
                !node.computed) {
         magicString.overwrite(node.object.start, node.object.end, '__non_webpack_require__');
+        transformed = true;
+      }
+      else if (!isESM && node.type === 'Property' && node.value.type === 'Identifier' &&
+               node.value.name === 'require' && !shadowDepths.require) {
+        magicString.overwrite(node.value.start, node.value.end, '__non_webpack_require__');
         transformed = true;
       }
 

--- a/test/integration/vm2.js
+++ b/test/integration/vm2.js
@@ -1,0 +1,2 @@
+const {VM} = require('vm2');
+new VM().run('console.log("HELLO WORLD")');

--- a/test/unit/asset-fs-inline-tpl/asset.txt
+++ b/test/unit/asset-fs-inline-tpl/asset.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/asset-fs-inline-tpl/input.js
+++ b/test/unit/asset-fs-inline-tpl/input.js
@@ -1,0 +1,2 @@
+const fs = require('fs');
+console.log(fs.readFileSync(`${__dirname}/asset.txt`));

--- a/test/unit/asset-fs-inline-tpl/output-coverage.js
+++ b/test/unit/asset-fs-inline-tpl/output-coverage.js
@@ -1,0 +1,55 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(717);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 717:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(__dirname + '/asset.txt'));
+
+/***/ })
+
+/******/ });

--- a/test/unit/asset-fs-inline-tpl/output.js
+++ b/test/unit/asset-fs-inline-tpl/output.js
@@ -1,0 +1,55 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(717);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 717:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(__dirname + '/asset.txt'));
+
+/***/ })
+
+/******/ });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11689,6 +11689,11 @@ vlq@^0.2.2:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
   integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
+vm2@^3.6.6:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.6.6.tgz#169048f0139cf0d0e7c26597ba6ae78af72b28a8"
+  integrity sha512-SXC941SEoL0c8+qe+N/PVYsck6vN6fzdkObISlF+YlCHeMCHhHsFD4yuydr1azEYqE8qgxHHkGPOd+iiV9sUyA==
+
 vue-server-renderer@^2.5.17:
   version "2.5.17"
   resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.5.17.tgz#c1f24815a4b12a2797c154549b29b44b6be004b5"


### PR DESCRIPTION
The fixes here are:

1. Use the global require when it is assigned into a property for use in the VM context.
2. The `context.js` and `sandbox.js` files need to be emitted as assets, and currently we don't emit ".js" assets.

Note that emitting ".js" files as assets will add to the output files list for lots of other builds, but it is the only way to get this to work, short of restricting this ".js" file output specifically to vm2 or something like that.