### PR TITLE
Ensure build folder is cleared properly on each run

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 const ncc = require("../src/index.js");
-const { statSync, writeFileSync, readFileSync } = require("fs");
+const { statSync, writeFileSync, readFileSync, unlinkSync } = require("fs");
 const { promisify } = require("util");
 const { relative } = require("path");
 const copy = promisify(require("copy"));
@@ -7,6 +7,10 @@ const glob = promisify(require("glob"));
 const bytes = require("bytes");
 
 async function main() {
+  for (const file of await glob(__dirname + "/../dist/**/*.@(js|cache|ts)")) {
+    unlinkSync(file);
+  }
+
   const { code: cli, assets: cliAssets } = await ncc(
     __dirname + "/../src/cli",
     {


### PR DESCRIPTION
This will remove the current `typescript/typescript.js` which was left behind in the last build which will reduce the package size by 3MB!