### PR TITLE
Ensure local TypeScript is always a project-scoped lookup

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -99,16 +99,18 @@ async function main() {
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli);
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);
   writeFileSync(__dirname + "/../dist/ncc/typescript.js", `
+const { Module } = require('module');
+const m = new Module('', null);
+m.paths = Module._nodeModulePaths(process.env.TYPESCRIPT_LOOKUP_PATH || (process.cwd() + '/'));
 let typescript;
 try {
-  typescript = require('typescript');
+  typescript = m.require('typescript');
   console.log("ncc: Using typescript@" + typescript.version + " (local user-provided)");
 }
 catch (e) {
   typescript = require('./loaders/ts-loader.js').typescript;
   console.log("ncc: Using typescript@" + typescript.version + " (ncc built-in)");
 }
-
 module.exports = typescript;
 `);
   writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js", sourcemapSupport);

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ module.exports = (
   } = {}
 ) => {
   const resolvedEntry = resolve.sync(entry);
+  process.env.TYPESCRIPT_LOOKUP_PATH = resolvedEntry;
   const shebangMatch = fs.readFileSync(resolvedEntry).toString().match(shebangRegEx);
   const mfs = new MemoryFS();
   const assetNames = Object.create(null);
@@ -154,7 +155,7 @@ module.exports = (
           {
             loader: eval('__dirname + "/loaders/ts-loader.js"'),
             options: {
-              compiler: eval('__dirname + "/typescript"'),
+              compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
                 outDir: '//'
               }

--- a/src/loaders/ts-loader.js
+++ b/src/loaders/ts-loader.js
@@ -16,14 +16,9 @@ logger.makeLogger = function (loaderOptions, colors) {
   return instance;
 };
 
-const { getOptions } = require("loader-utils");
-const loader = require("ts-loader");
-module.exports = function () {
-  const options = getOptions(this);
-  if (!options.compiler)
-    options.compiler = eval('__dirname + "/../typescript"');
-  
-  return loader.apply(this, arguments);
-};
+module.exports = require("ts-loader");
 
+// ts-loader internally has a require("typescript") that applies
+// regardless of "compiler".
+// We could remap this too, as soon as ncc supports aliased externals
 module.exports.typescript = require("typescript");

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -1,0 +1,1 @@
+module.exports = require("typescript");

--- a/src/typescript/index.js
+++ b/src/typescript/index.js
@@ -1,1 +1,0 @@
-module.exports = require('typescript');


### PR DESCRIPTION
This updates the resolution of the local TypeScript lookup to be based on doing a node_modules lookup from the entry point itself of the `ncc` build operation. The previous check would only check for TypeScript once and from the ncc location, therefore using the `npm install -g typescript` instead of the local project TypeScript.

I'm working on a separate PR to add CLI runner coverage, and will include tests for this on that branch.