### PR TITLE
CLI Coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "./dist/ncc/index.js",
   "bin": {
-    "ncc": "./scripts/cli.js"
+    "ncc": "./dist/ncc/cli.js"
   },
   "scripts": {
     "build": "node scripts/build",

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-// we separate `src/cli` and `scripts/cli` so that we can launch `ncc`
-// against a pure-js file without the shebang. in the future,
-// ncc should support taking in an input with a shebang,
-// and preserving it in the output
-require('../dist/ncc/cli');

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,10 @@ module.exports = (
           test: /\.(js|mjs|tsx?)$/,
           use: [{
             loader: eval('__dirname + "/loaders/relocate-loader.js"'),
-            options: { cwd: dirname(resolvedEntry) }
+            options: {
+              cwd: dirname(resolvedEntry),
+              entryId: resolvedEntry
+            }
           }]
         },
         {

--- a/test/unit/main-equal/dep.js
+++ b/test/unit/main-equal/dep.js
@@ -1,0 +1,2 @@
+// this is a dep main check, so it is known to be false
+console.log(require.main === module);

--- a/test/unit/main-equal/input.js
+++ b/test/unit/main-equal/input.js
@@ -1,1 +1,3 @@
+require('./dep.js');
+// this is the entry main check, so it becomes an outer main check
 console.log(require.main === module);

--- a/test/unit/main-equal/output-coverage.js
+++ b/test/unit/main-equal/output-coverage.js
@@ -29,16 +29,12 @@ module.exports =
 /******/ 	}
 /******/
 /******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(__webpack_require__.s = 659);
+/******/ 		return __webpack_require__(659);
 /******/ 	};
-/******/ 	// initialize runtime
-/******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// run startup
 /******/ 	return startup();
@@ -46,34 +42,23 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 659:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ 542:
+/***/ (function() {
 
-/* module decorator */ module = __webpack_require__.nmd(module);
-console.log(__webpack_require__.c[__webpack_require__.s] === module);
+// this is a dep main check, so it is known to be false
+console.log(false);
+
+
+/***/ }),
+
+/***/ 659:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+__webpack_require__(542);
+// this is the entry main check, so it becomes an outer main check
+console.log(require.main === require.cache[eval('__filename')]);
+
 
 /***/ })
 
-/******/ },
-/******/ function(__webpack_require__) { // webpackRuntimeModules
-/******/ 	"use strict";
-/******/ 
-/******/ 	/* webpack/runtime/node module decorator */
-/******/ 	!function() {
-/******/ 		__webpack_require__.nmd = function(module) {
-/******/ 			module.paths = [];
-/******/ 			if (!module.children) module.children = [];
-/******/ 			Object.defineProperty(module, 'loaded', {
-/******/ 				enumerable: true,
-/******/ 				get: function() { return module.l; }
-/******/ 			});
-/******/ 			Object.defineProperty(module, 'id', {
-/******/ 				enumerable: true,
-/******/ 				get: function() { return module.i; }
-/******/ 			});
-/******/ 			return module;
-/******/ 		};
-/******/ 	}();
-/******/ 	
-/******/ }
-);
+/******/ });

--- a/test/unit/main-equal/output.js
+++ b/test/unit/main-equal/output.js
@@ -29,16 +29,12 @@ module.exports =
 /******/ 	}
 /******/
 /******/
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(__webpack_require__.s = 858);
+/******/ 		return __webpack_require__(858);
 /******/ 	};
-/******/ 	// initialize runtime
-/******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// run startup
 /******/ 	return startup();
@@ -46,34 +42,23 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 858:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ 15:
+/***/ (function() {
 
-/* module decorator */ module = __webpack_require__.nmd(module);
-console.log(__webpack_require__.c[__webpack_require__.s] === module);
+// this is a dep main check, so it is known to be false
+console.log(false);
+
+
+/***/ }),
+
+/***/ 858:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+__webpack_require__(15);
+// this is the entry main check, so it becomes an outer main check
+console.log(require.main === require.cache[eval('__filename')]);
+
 
 /***/ })
 
-/******/ },
-/******/ function(__webpack_require__) { // webpackRuntimeModules
-/******/ 	"use strict";
-/******/ 
-/******/ 	/* webpack/runtime/node module decorator */
-/******/ 	!function() {
-/******/ 		__webpack_require__.nmd = function(module) {
-/******/ 			module.paths = [];
-/******/ 			if (!module.children) module.children = [];
-/******/ 			Object.defineProperty(module, 'loaded', {
-/******/ 				enumerable: true,
-/******/ 				get: function() { return module.l; }
-/******/ 			});
-/******/ 			Object.defineProperty(module, 'id', {
-/******/ 				enumerable: true,
-/******/ 				get: function() { return module.i; }
-/******/ 			});
-/******/ 			return module;
-/******/ 		};
-/******/ 	}();
-/******/ 	
-/******/ }
-);
+/******/ });


### PR DESCRIPTION
This implements coverage for the CLI by making the integration tests run through the cli driver directly, instead of only using the internal API.

Under this model, we use the API for the unit tests, and the CLI for the integration tests.

In order to get this to work easily with the coverage, I simply modified the CLI file to return an API interface when running in a non-CLI mode. This also required fixing the behaviour of the `require.main === module` check which should help many other build cases as well :)

Coverage is now around 80%, and we can continue to improve this still quite easily as well.