### PR TITLE
nodemon support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -283,10 +283,14 @@ async function runCmd (argv, stdout, stderr) {
                 reject({ silent: true, exitCode: code });
               process.off("SIGTERM", exit);
               process.off("SIGINT", exit);
+              process.off("SIGUSR1", exit);
+              process.off("SIGUSR2", exit);
             }
             ps.on("exit", exit);
             process.on("SIGTERM", exit);
             process.on("SIGINT", exit);
+            process.on("SIGUSR1", exit);
+            process.on("SIGUSR2", exit);
           });
         }
       }


### PR DESCRIPTION
This adds nodemon support for the SIGUSR2 handler, as described in https://github.com/zeit/ncc/issues/253#issue-404488287.