### PR TITLE
Override noEmit option for typescript compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,8 @@ module.exports = (
             options: {
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
-                outDir: '//'
+                outDir: '//',
+                noEmit: false
               }
             }
           }]


### PR DESCRIPTION
Given the clarification in https://github.com/zeit/ncc/issues/239#issuecomment-459412537 the problematic case is simply when `tsconfig.json` contains `noEmit: true`, and we don't want this configuration option to apply.

The fix really is this simple then.