### PR TITLE
run -f as the default

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -102,8 +102,6 @@ async function runCmd (argv, stdout, stderr) {
     args = require("arg")({
       "--external": [String],
       "-e": "--external",
-      "--force": Boolean,
-      "-f": "--force",
       "--out": String,
       "-o": "--out",
       "--minify": Boolean,
@@ -180,17 +178,8 @@ async function runCmd (argv, stdout, stderr) {
         require("os").tmpdir(),
         crypto.createHash('md5').digest(resolve(args._[1] || ".")).toString('hex')
       );
-      if (fs.existsSync(outDir)) {
-        if (args["--force"]) {
-          rimraf.sync(outDir);
-        }
-        else {
-          nccError(
-            `Error: Application at ${args._[1] || "."} is already running or didn't cleanup after previous run.\n` +
-            `To force clear the last run build, try running the "ncc run -f" flag.`
-          );
-        }
-      }
+      if (fs.existsSync(outDir))
+        rimraf.sync(outDir);
       run = true;
 
     // fallthrough

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,10 +4,6 @@
     expect: { code: 0 }
   },
   {
-    args: ["run", "-f", "test/integration/test.ts"],
-    expect: { code: 0 }
-  },
-  {
     args: ["run", "test/fixtures/error.js"],
     expect: { code: 1 }
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,7 +91,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
     const stdout = new StoreStream();
     const stderr = new StoreStream();
     try {
-      await nccRun(["run", "-f", `${__dirname}/integration/${integrationTest}`], stdout, stderr);
+      await nccRun(["run", "--no-cache", `${__dirname}/integration/${integrationTest}`], stdout, stderr);
     }
     catch (e) {
       if (e.silent) {


### PR DESCRIPTION
This avoids the annoying message about left-over temporary build files on previous `ncc run` calls, and just always attempts to remove these files on `ncc run`.

This also avoids the need for the PR https://github.com/zeit/ncc/pull/258.