### PR TITLE
Clean up sourcemap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -287,6 +287,23 @@ module.exports = (
     let code = mfs.readFileSync(`/${filename}`, "utf8");
     let map = sourceMap ? mfs.readFileSync(`/${filename}.map`, "utf8") : null;
 
+    if (map) {
+      map = JSON.parse(map);
+      map.sources = map.sources.map(source => {
+        if (source.startsWith('webpack:///'))
+          source = source.substr(11);
+        // webpack:///webpack:/// happens too for some reason
+        if (source.startsWith('webpack:///'))
+          source = source.substr(11);
+        if (source.startsWith('./'))
+          source = source.substr(2);
+        if (source.startsWith('webpack/'))
+          return '/webpack:' + source.substr(8);
+        return '/' + source;
+      });
+      map = JSON.stringify(map);
+    }
+
     if (minify) {
       const result = terser.minify(code, {
         compress: false,


### PR DESCRIPTION
This cleans up the source map output such that instead of getting:

```
/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/webpack:/test.js:4
throw new Error('test');
^
Error: test
    at Object.294 (/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/webpack:/test.js:4:1)
    at __webpack_require__ (/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/webpack:/webpack/bootstrap:19:1)
    at startup (/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/webpack:/webpack/bootstrap:33:1)
    at /private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/webpack:/webpack/bootstrap:37:1
    at Object.<anonymous> (/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/index.js:43:10)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```

we will now get:

```
/test.js:4
throw new Error('test');
^
Error: test
    at Object.294 (/test.js:4:1)
    at __webpack_require__ (/webpack:bootstrap:19:1)
    at startup (/webpack:bootstrap:33:1)
    at /webpack:bootstrap:37:1
    at Object.<anonymous> (/private/var/folders/bm/grflgmxs62g01cd9m8sjjm740000gn/T/d41d8cd98f00b204e9800998ecf8427e/index.js:43:10)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```