### PR TITLE
Automatically include sourcemap-register in source map builds

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -269,9 +269,6 @@ async function runCmd (argv, stdout, stderr) {
           if (nodeModulesDir)
             fs.symlinkSync(nodeModulesDir, outDir + "/node_modules", "junction");
           ps = require("child_process").fork(outDir + "/index.js", {
-            execArgv: map
-              ? ["-r", resolve(__dirname, "sourcemap-register")]
-              : [],
             stdio: api ? 'pipe' : 'inherit'
           });
           if (api) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,10 @@ module.exports = (
     assetPermissions: undefined
   };
   assetState.assetNames[filename] = true;
-  if (sourceMap)
+  if (sourceMap) {
     assetState.assetNames[filename + '.map'] = true;
+    assetState.assetNames['sourcemap-register.js'] = true;
+  }
   nodeLoader.setAssetState(assetState);
   relocateLoader.setAssetState(assetState);
   // add TsconfigPathsPlugin to support `paths` resolution in tsconfig
@@ -325,6 +327,11 @@ module.exports = (
       // add a line offset to the sourcemap
       if (map)
         map.mappings = ";" + map.mappings;
+    }
+
+    if (map) {
+      code = `require('./sourcemap-register.js');` + code;
+      assets['sourcemap-register.js'] = { source: fs.readFileSync(__dirname + "/sourcemap-register.js.cache.js"), permissions: 0o666 };
     }
 
     return { code, map, assets };

--- a/src/sourcemap-register.js.cache.js
+++ b/src/sourcemap-register.js.cache.js
@@ -1,0 +1,1 @@
+../dist/ncc/sourcemap-register.js.cache.js


### PR DESCRIPTION
This implements #180 including the `sourcemap-register.js` file as an asset of any `ncc build -s` call (it's 122KB). The build file is then updated to require this file first to provide source map support in Node.js for any execution errors.