### PR TITLE
Ensure that any __non_webpack_require__ is retained in subsequent builds

### DIFF
--- a/test/unit/require-check/input.js
+++ b/test/unit/require-check/input.js
@@ -1,0 +1,2 @@
+const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
+const foo = requireFunc(moduleName);

--- a/test/unit/require-check/output-coverage.js
+++ b/test/unit/require-check/output-coverage.js
@@ -1,0 +1,54 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(155);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 155:
+/***/ (function() {
+
+const requireFunc =  true ? eval("require") : undefined;
+const foo = requireFunc(moduleName);
+
+
+/***/ })
+
+/******/ });

--- a/test/unit/require-check/output.js
+++ b/test/unit/require-check/output.js
@@ -1,0 +1,54 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(805);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 805:
+/***/ (function() {
+
+const requireFunc =  true ? eval("require") : undefined;
+const foo = requireFunc(moduleName);
+
+
+/***/ })
+
+/******/ });


### PR DESCRIPTION
This is an interesting one, basically when an ncc build is again built, any instances of the following pattern:

```js
const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
```

will be converted into:

```js
const requireFunc = false ? require : undefined;
```

by Webpack. And as a result the pattern breaks on the second build.

Fixed by injecting a phase before that avoids this double rewriting.

//cc @sokra this seems to be a breakdown in build transitivity in Webpack.