### PR TITLE
Include version in bulid output

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ const rimraf = require("rimraf");
 const crypto = require("crypto");
 const fs = require("fs");
 const mkdirp = require("mkdirp");
+const nccVersion = require('../package.json').version;
 
 const usage = `Usage: ncc <cmd> <opts>
 
@@ -99,7 +100,7 @@ function renderSummary(code, map, assets, outDir, buildTime) {
   }
   if (indexMapRender) output += (first ? "" : "\n") + indexMapRender;
 
-  output += `\n${totalSize}kB  [${buildTime}ms]`;
+  output += `\n${totalSize}kB  [${buildTime}ms] - ncc ${nccVersion}`;
 
   return output;
 }


### PR DESCRIPTION
This updates the build output to include the version on the last line:

```
    8kB  dist/puppeteer-core/CONTRIBUTING.md
   11kB  dist/puppeteer-core/LICENSE
   18kB  dist/puppeteer-core/README.md
   87kB  dist/Inter-Regular.woff2
   94kB  dist/Inter-Bold.woff2
  782kB  dist/source/iltorb/build/bindings/iltorb.node
 1157kB  dist/index.js
35035kB  dist/bin/chromium-72.0.3617.0.br
37194kB  [2941ms] ncc - 0.15.0
```

formatting suggestions welcome too.