### PR TITLE
Fix to asset permissions to work even when relocator loader doesn't run

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@google-cloud/bigquery": "^2.0.1",
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.1.5",
+    "@zeit/webpack-asset-relocator-loader": "0.1.8",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,7 @@ module.exports = (
     plugins: [
       {
         apply(compiler) {
+          compiler.hooks.compilation.tap("relocate-loader", relocateLoader.initAssetPermissionsCache);
           compiler.hooks.watchRun.tap("ncc", () => {
             if (rebuildHandler)
               rebuildHandler();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@zeit/webpack-asset-relocator-loader@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.1.4.tgz#4f3ef702039460d6d8e42075310a0df97c15c673"
-  integrity sha512-/ODMfRVFrgNGcISbPqrq1bkjoXZ0LJDGQ+XMbaIG9Um3FxVz1mMpdSGV7ICBrRimLMkN44AynfmIyKpk3J5ehw==
+"@zeit/webpack-asset-relocator-loader@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.1.8.tgz#9da7ad7de520d612b11c4346ecf6b24891db7e99"
+  integrity sha512-Oi1EqKl787S4dlDwNcpODMnYv1pY/4btA8r67I2W9XqFSjNoU/Zih0hz9D3uIN4dU9R0aoEoSRTjQKrSzRiB6A==
 
 JSONStream@^1.3.1, JSONStream@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
A little more wiring was required to get the cache persistence of the asset relocator loader as included in the call here and the update at https://github.com/zeit/webpack-asset-relocator-loader/commit/404d6ccf5eafc68603e436e5316d2eeed180ccf1.