### PR TITLE
--no-source-map-register support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,10 +68,13 @@ require('@zeit/ncc')('/path/to/input', {
   externals: ["externalpackage"],
   minify: false, // default
   sourceMap: false, // default
+  // when outputting a sourcemap, automatically include
+  // source-map-support in the output file (increases output by 32kB).
+  sourceMapRegister: true, // default
   watch: false // default
 }).then(({ code, map, assets }) => {
   console.log(code);
-  // assets is an object of asset file names to { source, permissions }
+  // Assets is an object of asset file names to { source, permissions }
   // expected relative to the output code (if any)
 })
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,14 +19,15 @@ Commands:
   version
 
 Options:
-  -o, --out [file]      Output directory for build (defaults to dist)
-  -m, --minify          Minify output
-  -C, --no-cache        Skip build cache population
-  -s, --source-map      Generate source map
-  -e, --external [mod]  Skip bundling 'mod'. Can be used many times
-  -q, --quiet           Disable build summaries / non-error outputs
-  -w, --watch           Start a watched build
-  --v8-cache            Emit a build using the v8 compile cache
+  -o, --out [file]         Output directory for build (defaults to dist)
+  -m, --minify             Minify output
+  -C, --no-cache           Skip build cache population
+  -s, --source-map         Generate source map
+  --no-source-map-register Skip source-map-register source map support
+  -e, --external [mod]     Skip bundling 'mod'. Can be used many times
+  -q, --quiet              Disable build summaries / non-error outputs
+  -w, --watch              Start a watched build
+  --v8-cache               Emit a build using the v8 compile cache
 `;
 
 // support an API mode for CLI testing
@@ -126,6 +127,7 @@ async function runCmd (argv, stdout, stderr) {
       "-s": "--source-map",
       "--no-cache": Boolean,
       "-C": "--no-cache",
+      "--no-source-map-register": Boolean,
       "--quiet": Boolean,
       "-q": "--quiet",
       "--watch": Boolean,
@@ -137,11 +139,11 @@ async function runCmd (argv, stdout, stderr) {
     });
   } catch (e) {
     if (e.message.indexOf("Unknown or unexpected option") === -1) throw e;
-    nccError(e.message + `\n${usage}`);
+    nccError(e.message + `\n${usage}`, 2);
   }
 
   if (args._.length === 0)
-    nccError(`Error: No command specified\n${usage}`);
+    nccError(`Error: No command specified\n${usage}`, 2);
 
   let run = false;
   let outDir = args["--out"];
@@ -212,6 +214,7 @@ async function runCmd (argv, stdout, stderr) {
           minify: args["--minify"],
           externals: args["--external"],
           sourceMap: args["--source-map"] || run,
+          sourceMapRegister: args["--no-source-map-register"] ? false : undefined,
           cache: args["--no-cache"] ? false : undefined,
           watch: args["--watch"],
           v8cache: args["--v8-cache"]

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = (
     filename = "index.js",
     minify = false,
     sourceMap = false,
+    sourceMapRegister = true,
     watch = false,
     v8cache = false
   } = {}
@@ -312,7 +313,7 @@ module.exports = (
       if (map) map = {};
     }
 
-    if (map) {
+    if (map && sourceMapRegister) {
       code = `require('./sourcemap-register.js');` + code;
       assets['sourcemap-register.js'] = { source: fs.readFileSync(__dirname + "/sourcemap-register.js.cache.js"), permissions: 0o666 };
     }

--- a/test/cli.js
+++ b/test/cli.js
@@ -12,6 +12,12 @@
     expect: { code: 1 }
   },
   {
+    args: ["run", "test/fixtures/error.js", "--no-source-map-register"],
+    expect (code, stdout, stderr) {
+      return code === 1 && stderr.toString().indexOf('fixtures/error.js') === -1;
+    }
+  },
+  {
     args: ["run", "--watch", "test/integration/test.ts"],
     expect: { code: 2 }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,9 +38,14 @@ for (const cliTest of eval(fs.readFileSync(__dirname + "/cli.js").toString())) {
     const ps = fork(__dirname + (global.coverage ? "/../src/cli.js" : "/../dist/ncc/cli.js"), cliTest.args || [], {
       stdio: "pipe"
     });
+    let stderr = "", stdout = "";
+    ps.stderr.on("data", chunk => stderr += chunk.toString());
+    ps.stdout.on("data", chunk => stdout += chunk.toString());
     const expected = cliTest.expect || { code: 0 };
     const code = await new Promise(resolve => ps.on("close", resolve));
-    if ('code' in expected)
+    if (typeof expected === "function")
+      expect(expected(code, stdout, stderr)).toBe(true);
+    else if ("code" in expected)
       expect(code).toBe(expected.code);
   });
 }


### PR DESCRIPTION
This implements an opt-out for the automatic source map registration that was included in https://github.com/zeit/ncc/pull/270.

The use case for this is source maps as described in https://github.com/zeit/ncc/issues/180#issuecomment-455862395 and the next comment there.