### PR TITLE
Support fallback requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@google-cloud/bigquery": "^2.0.1",
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.1.10",
+    "@zeit/webpack-asset-relocator-loader": "0.1.12",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@zeit/webpack-asset-relocator-loader@0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.1.10.tgz#2d8c79b01526837436884f22563e9dead39c8f2f"
-  integrity sha512-uqqxPSaRfr2lqYwwFE0f0bNKbk1fR+2oPCmzr9fMRIXUMGcnlzYIIVjdmVf7qxHBSI5O9RWdiyeOLpL84ubz2A==
+"@zeit/webpack-asset-relocator-loader@0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.1.12.tgz#a9c52fcfeb5449479052e70547fd3d7a478a1bb8"
+  integrity sha512-mKiIAeUAh/TYjBcvTiU1I76jF94g9jHdAktk5MXktgW6UuYAQ5RUz7c3OPPqMrs0n5PeCPwlYDjQaYnVSviN1g==
 
 JSONStream@^1.3.1, JSONStream@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This includes an upgrade to the asset relocator loader to fix https://github.com/zeit/ncc/issues/284.

The unit test case is included in the commit there - https://github.com/zeit/webpack-asset-relocator-loader/commit/e082f9b09574631cf64bf6de006b7e42d57b07e0.

A full integration test is still pending on this one. @Siyfion perhaps you can share a full example repo or test this out in your replication there?