### PR TITLE
Update browserify wrapper handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "stripe": "^6.15.0",
     "terser": "^3.11.0",
     "the-answer": "^1.0.0",
+    "tiny-json-http": "^7.0.2",
     "ts-loader": "^5.3.1",
     "tsconfig-paths": "^3.7.0",
     "tsconfig-paths-webpack-plugin": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.2.2",
+    "@zeit/webpack-asset-relocator-loader": "0.2.3",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",

--- a/test/integration/tiny-json-http.js
+++ b/test/integration/tiny-json-http.js
@@ -1,0 +1,1 @@
+const tiny = require('tiny-json-http');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@zeit/webpack-asset-relocator-loader@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.2.2.tgz#f483a8d2f16c2058d4979613787f52af4cf8f835"
-  integrity sha512-nuU8gm6N2GCmxGSyp7AJ5VY3fwefK5oiLBERfJyceUNHFyGWNhiBUaGg/L9I9fcptxvaxoBbt2uqts7BiJqznw==
+"@zeit/webpack-asset-relocator-loader@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.2.3.tgz#ee4790d032d228b10afc7e4b616b0d86c51628b2"
+  integrity sha512-LfGRLqh0ZOYbiqEZlk8eTLEV4G6KTlruVTGRn27Dczkur3gVh+91oTy8xwf2LY64hpJWSNcKm+pU23xa/hk29w==
 
 JSONStream@^1.3.1, JSONStream@^1.3.4, JSONStream@^1.3.5:
   version "1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11637,6 +11637,11 @@ tiny-inflate@^1.0.0, tiny-inflate@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.2.tgz#93d9decffc8805bd57eae4310f0b745e9b6fb3a7"
   integrity sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c=
 
+tiny-json-http@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-json-http/-/tiny-json-http-7.0.2.tgz#be5a52d75d4a92046bc1c5c99a928b49eee1cd6b"
+  integrity sha512-5MsAvlq5tvgCY98Y7iQPmpP5ZqLzESrv/S5AwXWIvHL0Z0zVVAfWku7WC6V4rHJb+judXhd28KBnE5+FLOVYaQ==
+
 tiny-relative-date@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"


### PR DESCRIPTION
This includes the update to the asset relocator loader to improve the Browserify wrapper handling (https://github.com/zeit/webpack-asset-relocator-loader/commit/2d0e7c7e2cc4a2df2baf8803867f186cb4e5dce1).

Specifically we extend the browserify wrapper detection to be able to detect the uglification of the wrapper, as well as ensuring that the require detection is converted to apply to `__non_webpack_require__`.

Fixes #299.