### PR TITLE
Fixup tests on mac including asset symlinks support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.2.3",
+    "@zeit/webpack-asset-relocator-loader": "0.3.1",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ require('@zeit/ncc')('/path/to/input', {
   watch: false // default
 }).then(({ code, map, assets }) => {
   console.log(code);
-  // Assets is an object of asset file names to { source, permissions }
+  // Assets is an object of asset file names to { source, permissions, symlinks }
   // expected relative to the output code (if any)
 })
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -221,7 +221,7 @@ async function runCmd (argv, stdout, stderr) {
         }
       );
 
-      async function handler ({ err, code, map, assets }) {
+      async function handler ({ err, code, map, assets, symlinks }) {
         // handle watch errors
         if (err) {
           stderr.write(err + '\n');
@@ -246,6 +246,11 @@ async function runCmd (argv, stdout, stderr) {
           const assetPath = outDir + "/" + asset;
           mkdirp.sync(dirname(assetPath));
           fs.writeFileSync(assetPath, assets[asset].source, { mode: assets[asset].permissions });
+        }
+
+        for (const symlink of Object.keys(symlinks)) {
+          const symlinkPath = outDir + "/" + symlink;
+          fs.symlinkSync(symlinks[symlink], symlinkPath);
         }
 
         if (!args["--quiet"]) {

--- a/src/index.js
+++ b/src/index.js
@@ -259,6 +259,7 @@ module.exports = (
 
   function finalizeHandler () {
     const assets = Object.create(null);
+    const symlinks = Object.assign(Object.create(null), relocateLoader.getSymlinks());
     getFlatFiles(mfs.data, assets, relocateLoader.getAssetPermissions);
     delete assets[filename];
     delete assets[filename + ".map"];
@@ -327,7 +328,7 @@ module.exports = (
         map.mappings = ";" + map.mappings;
     }
 
-    return { code, map, assets };
+    return { code, map, assets, symlinks };
   }
 };
 


### PR DESCRIPTION
This updates the webpack-asset-relocator-loader to support the tfjs-node build that was failing on MacOS.

The failure was due to shared libraries with .so extensions not begin emitted on mac, and also due to not having support for symlinked assets, as the pathing of the shared library relies on symlinks. Both of these are fixed in the latest webpack-asset-relocator-loader release at https://github.com/zeit/webpack-asset-relocator-loader/commit/23b0dbffce22fbe19f51c292a73f40ba82ab8386.