### PR TITLE
Update to webpack-asset-relocator-loader@0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.3.1",
+    "@zeit/webpack-asset-relocator-loader": "0.3.2",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@zeit/webpack-asset-relocator-loader@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.3.1.tgz#c69170d2ad541328eb354e7329d0c64362e95561"
-  integrity sha512-AXXm7QD1Zq3kggeBxRKF95ArA4mmr7VRySPgnuF8pUZuS6c4R9t8hdZFDSp8w5e0+fMaQ0LiPG2mCXv8sMUnEw==
+"@zeit/webpack-asset-relocator-loader@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.3.2.tgz#f761009259822867d8202e6d28ac2de55606bc2f"
+  integrity sha512-u6fomjSvrV44KpH7tCFrXrYco2v0BuB1/nouT7MomKImcNNfPBdqJsnt4RvpyjyiUswJMe0qBiFRutq1Jv6Ygg==
 
 JSONStream@^1.3.1, JSONStream@^1.3.4, JSONStream@^1.3.5:
   version "1.3.5"


### PR DESCRIPTION
This includes the updates for correct parser errors, the express templates support, as well as firebase admin support.

We have tests for all the above in the asset relocator loader itself, although the firebase-admin case is not a full integration test as that would involve storing credentials.

Fixes #317
Fixes #323 