### PR TITLE
Print version from programatic API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,9 @@ require('@zeit/ncc')('/path/to/input', {
   // when outputting a sourcemap, automatically include
   // source-map-support in the output file (increases output by 32kB).
   sourceMapRegister: true, // default
-  watch: false // default
+  watch = false, // default
+  v8cache = false, // default
+  quiet = false // default
 }).then(({ code, map, assets }) => {
   console.log(code);
   // Assets is an object of asset file names to { source, permissions, symlinks }

--- a/src/cli.js
+++ b/src/cli.js
@@ -147,6 +147,7 @@ async function runCmd (argv, stdout, stderr) {
 
   let run = false;
   let outDir = args["--out"];
+  const quiet = args["--quiet"];
 
   switch (args._[0]) {
     case "cache":
@@ -217,7 +218,8 @@ async function runCmd (argv, stdout, stderr) {
           sourceMapRegister: args["--no-source-map-register"] ? false : undefined,
           cache: args["--no-cache"] ? false : undefined,
           watch: args["--watch"],
-          v8cache: args["--v8-cache"]
+          v8cache: args["--v8-cache"],
+          quiet
         }
       );
 
@@ -253,7 +255,7 @@ async function runCmd (argv, stdout, stderr) {
           fs.symlinkSync(symlinks[symlink], symlinkPath);
         }
 
-        if (!args["--quiet"]) {
+        if (!quiet) {
           stdout.write( 
             renderSummary(
               code,

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ module.exports = (
 ) => {
   if (!quiet) {
     console.log('ncc: Version ' + nccVersion);
+    console.log('ncc: Compiling file ' + filename);
   }
   const resolvedEntry = resolve.sync(entry);
   process.env.TYPESCRIPT_LOOKUP_PATH = resolvedEntry;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const shebangRegEx = require('./utils/shebang');
 const { pkgNameRegEx } = require("./utils/get-package-base");
 const nccCacheDir = require("./utils/ncc-cache-dir");
+const nccVersion = require('../package.json').version;
 
 // support glob graceful-fs
 fs.gracefulify(require("fs"));
@@ -38,9 +39,13 @@ module.exports = (
     sourceMap = false,
     sourceMapRegister = true,
     watch = false,
-    v8cache = false
+    v8cache = false,
+    quiet = false
   } = {}
 ) => {
+  if (!quiet) {
+    console.log('ncc: Version ' + nccVersion);
+  }
   const resolvedEntry = resolve.sync(entry);
   process.env.TYPESCRIPT_LOOKUP_PATH = resolvedEntry;
   const shebangMatch = fs.readFileSync(resolvedEntry).toString().match(shebangRegEx);


### PR DESCRIPTION
This will print the ncc version and the file being compiled when using the programmatic API `const ncc = require('ncc')`. Previously, we were only printing the version when the CLI was used.

I also added `quiet` so that the programmatic API can enable/disable quiet mode.