### PR TITLE
Relative sourcemap base

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ require('@zeit/ncc')('/path/to/input', {
   externals: ["externalpackage"],
   minify: false, // default
   sourceMap: false, // default
+  sourceMapBasePrefix: '../' // default treats sources as output-relative
   // when outputting a sourcemap, automatically include
   // source-map-support in the output file (increases output by 32kB).
   sourceMapRegister: true, // default

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ module.exports = (
     sourceMap = false,
     sourceMapRegister = true,
     watch = false,
-    v8cache = false
+    v8cache = false,
+    sourceMapBasePrefix = '../',
   } = {}
 ) => {
   const resolvedEntry = resolve.sync(entry);
@@ -274,17 +275,16 @@ module.exports = (
 
     if (map) {
       map = JSON.parse(map);
+      // make source map sources relative to output
       map.sources = map.sources.map(source => {
-        if (source.startsWith('webpack:///'))
-          source = source.substr(11);
         // webpack:///webpack:/// happens too for some reason
-        if (source.startsWith('webpack:///'))
+        while (source.startsWith('webpack:///'))
           source = source.substr(11);
         if (source.startsWith('./'))
           source = source.substr(2);
         if (source.startsWith('webpack/'))
-          return '/webpack:' + source.substr(8);
-        return '/' + source;
+          return '/webpack/' + source.substr(8);
+        return sourceMapBasePrefix + source;
       });
       map = JSON.stringify(map);
     }


### PR DESCRIPTION
This fixes #319, by ensuring that the source maps paths match up to the input folder, using a custom `sourceMapsBasePrefix` option.

Ideally the CLI should know to configure this option based on the output directory location relative pathing, but by default it will likely usually be `../`.

I compared the source maps here to the ones generated by TypeScript and the output file is pretty much identical now, but when I tried testing with `node --inspect-brk` in the Chrome dev tools, I still couldn't get the source map to apply.

I ran the source maps in the Webpack visualizer at https://sokra.github.io/source-map-visualization and can confirm they are all working 100%.

The only thing I can think here is either if my local setup isn't running file system source maps for some reason (so @styfle perhaps you can verify your side), or if the Webpack boostrap file is somehow making things invalid as it is the first source (`"/webpack/bootstrap"`). I tried changing this name to different forms but that didn't seem to make a difference.

Not sure what else to try, but source maps debugging is always like this the first time :)
