### PR TITLE
Update webpack-asset-relocator-loader@0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.3.2",
+    "@zeit/webpack-asset-relocator-loader": "0.3.3",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^2.0.0",


### PR DESCRIPTION
Fixes #330 - This updates the asset loader to 0.3.3 which is directly tested in the loader there.