### PR TITLE
fix: incorrect usage of Hash.digest

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -196,7 +196,7 @@ async function runCmd (argv, stdout, stderr) {
 
       outDir = resolve(
         require("os").tmpdir(),
-        crypto.createHash('md5').digest(resolve(args._[1] || ".")).toString('hex')
+        crypto.createHash('md5').update(resolve(args._[1] || ".")).digest('hex')
       );
       if (existsSync(outDir))
         rimraf.sync(outDir);


### PR DESCRIPTION
Hey,

Hash.digest expect an encoding value as parameter(latin1 | hex | base64).

The absolute path of the file was passed to `Hash.digest` which is incorrect. To generate a hash
based on the pathname we have to call `Hash.update` first.

The desired encoding format is then passed to `Hash.digest`. This remove the need to call `toString` method.