### PR TITLE
Expose custom watcher

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,6 +224,28 @@ module.exports = (
     .then(finalizeHandler);
   }
   else {
+    if (typeof watch === 'object') {
+      if (!watch.watch)
+        throw new Error('Watcher class must be a valid Webpack WatchFileSystem class instance (https://github.com/webpack/webpack/blob/master/lib/node/NodeWatchFileSystem.js)');
+      compiler.watchFileSystem = watch;
+      watch.inputFileSystem = compiler.inputFileSystem;
+    }
+    else {
+      // Used for inspecting Webpack watcher API
+      /*
+      const w = compiler.watchFileSystem.watch;
+      compiler.watchFileSystem.watch = function (files, dirs, missing, startTime, options, callback, callbackUndelayed) {
+        const cb = function () {
+          const timestamps = {};
+          for (const [key, value] of arguments[1].entries())
+            timestamps[key] = value;
+          console.log(JSON.stringify(timestamps));
+          callback.apply(this, arguments);
+        };
+        return w.call(this, files, dirs, missing, startTime, options, cb, callbackUndelayed);
+      };
+      */
+    }
     let cachedResult;
     watcher = compiler.watch({}, (err, stats) => {
       if (err)
@@ -232,7 +254,7 @@ module.exports = (
         return watchHandler({ err: stats.toString() });
       const returnValue = finalizeHandler();
       // clear output file system
-      mfs.data = {};
+      // mfs.data = {};
       if (watchHandler)
         watchHandler(returnValue);
       else

--- a/src/index.js
+++ b/src/index.js
@@ -230,22 +230,6 @@ module.exports = (
       compiler.watchFileSystem = watch;
       watch.inputFileSystem = compiler.inputFileSystem;
     }
-    else {
-      // Used for inspecting Webpack watcher API
-      /*
-      const w = compiler.watchFileSystem.watch;
-      compiler.watchFileSystem.watch = function (files, dirs, missing, startTime, options, callback, callbackUndelayed) {
-        const cb = function () {
-          const timestamps = {};
-          for (const [key, value] of arguments[1].entries())
-            timestamps[key] = value;
-          console.log(JSON.stringify(timestamps));
-          callback.apply(this, arguments);
-        };
-        return w.call(this, files, dirs, missing, startTime, options, cb, callbackUndelayed);
-      };
-      */
-    }
     let cachedResult;
     watcher = compiler.watch({}, (err, stats) => {
       if (err)
@@ -254,7 +238,7 @@ module.exports = (
         return watchHandler({ err: stats.toString() });
       const returnValue = finalizeHandler();
       // clear output file system
-      // mfs.data = {};
+      mfs.data = {};
       if (watchHandler)
         watchHandler(returnValue);
       else

--- a/src/index.js
+++ b/src/index.js
@@ -237,8 +237,6 @@ module.exports = (
       if (stats.hasErrors())
         return watchHandler({ err: stats.toString() });
       const returnValue = finalizeHandler();
-      // clear output file system
-      mfs.data = {};
       if (watchHandler)
         watchHandler(returnValue);
       else

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -58,10 +58,13 @@ class CustomWatchFileSystem {
     this.dirs = new Set(dirs);
     this.missing = new Set(missing);
 
+    // empty object indicates "unknown" timestamp
+    // (that is, not cached)
     for (const item of files)
       this.timestamps.set(item, {});
     for (const item of dirs)
       this.timestamps.set(item, {});
+    // null represents "no file"
     for (const item of missing)
       this.timestamps.set(item, null);
 

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -73,7 +73,7 @@ class CustomWatchFileSystem {
       this.watchStart(files, dirs, missing);
     });
 		
-		return {
+    return {
       close: () => {
         this.watchEnd();
       },
@@ -86,8 +86,8 @@ class CustomWatchFileSystem {
       getContextTimestamps: () => {
         return this.timestamps;
       }
-		};
-	}
+    };
+  }
 }
 
 jest.setTimeout(20000);

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 // - https://www.npmjs.com/package/watchpack
 
 class CustomWatchFileSystem {
-	constructor(watchStart, watchEnd) {
+  constructor(watchStart, watchEnd) {
     this.closed = false;
     // paused allows the watchers to stay open for the next build
     this.paused = false;
@@ -44,16 +44,16 @@ class CustomWatchFileSystem {
         this.inputFileSystem.purge(file);
 
       this.changeCallback(
-				null,
-				this.timestamps,
-				this.timestamps,
-				removed
+        null,
+        this.timestamps,
+        this.timestamps,
+        removed
       );
     }
   }
 
   // This is called on every rebuild
-	watch (files, dirs, missing, startTime, options, changeCallback) {
+  watch (files, dirs, missing, startTime, options, changeCallback) {
     this.files = new Set(files);
     this.dirs = new Set(dirs);
     this.missing = new Set(missing);
@@ -74,18 +74,18 @@ class CustomWatchFileSystem {
     });
 		
 		return {
-			close: () => {
-				this.watchEnd();
-			},
-			pause: () => {
-				this.paused = true;
-			},
-			getFileTimestamps: () => {
-				return this.timestamps;
-			},
-			getContextTimestamps: () => {
-				return this.timestamps;
-			}
+      close: () => {
+        this.watchEnd();
+      },
+      pause: () => {
+        this.paused = true;
+      },
+      getFileTimestamps: () => {
+        return this.timestamps;
+      },
+      getContextTimestamps: () => {
+        return this.timestamps;
+      }
 		};
 	}
 }

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -1,0 +1,131 @@
+const path = require('path');
+const ncc = (global.coverage || true) ? require("../src/index") : require("../");
+
+// Based on the NodeWatchFileSystem class at:
+// - https://github.com/webpack/webpack/blob/master/lib/node/NodeWatchFileSystem.js
+// which in turn exposes:
+// - https://www.npmjs.com/package/watchpack
+
+class CustomWatchFileSystem {
+	constructor(watchStart, watchEnd) {
+    this.closed = false;
+    // paused allows the watchers to stay open for the next build
+    this.paused = false;
+    this.changeCallback = undefined;
+    this.watchStart = watchStart;
+    this.watchEnd = watchEnd;
+
+    // Webpack requires us to track this stuff
+    this.files = undefined;
+    this.dirs = undefined;
+    this.missing = undefined;
+    this.timestamps = new Map();
+
+    // this will be populated for us by ncc
+    this.inputFileSystem = undefined;
+  }
+  
+  triggerChanges (changed, removed) {
+    if (!this.paused) {
+      const newTime = +Date.now();
+      for (const file of changed)
+        this.timestamps.set(file, {
+          safeTime: newTime + 10,
+          accuracy: 10,
+          timestamp: newTime
+        });
+      for (const file of removed)
+        this.timestamps.set(file, null);
+
+      for (const file of changed)
+        this.inputFileSystem.purge(file);
+      for (const file of removed)
+        this.inputFileSystem.purge(file);
+
+      this.changeCallback(
+				null,
+				this.timestamps,
+				this.timestamps,
+				removed
+      );
+    }
+  }
+
+  // This is called on every rebuild
+	watch (files, dirs, missing, startTime, options, changeCallback) {
+    this.files = new Set(files);
+    this.dirs = new Set(dirs);
+    this.missing = new Set(missing);
+
+    for (const item of files)
+      this.timestamps.set(item, {});
+    for (const item of dirs)
+      this.timestamps.set(item, {});
+    for (const item of missing)
+      this.timestamps.set(item, null);
+
+    this.paused = false;
+    this.changeCallback = changeCallback;
+
+    // ...Start watching files, dirs, mising
+    setImmediate(() => {
+      this.watchStart(files, dirs, missing);
+    });
+		
+		return {
+			close: () => {
+				this.watchEnd();
+			},
+			pause: () => {
+				this.paused = true;
+			},
+			getFileTimestamps: () => {
+				return this.timestamps;
+			},
+			getContextTimestamps: () => {
+				return this.timestamps;
+			}
+		};
+	}
+}
+
+jest.setTimeout(10000);
+
+it('Should support custom watch API', async () => {
+  let buildCnt = 0;
+  const buildFile = path.resolve('./test/integration/twilio.js');
+  await new Promise((resolve, reject) => {
+    const watcher = new CustomWatchFileSystem(function watchStart (files, dirs, missing) {
+      expect(files.length).toBeGreaterThan(100);
+      expect(dirs.length).toBeGreaterThan(0);
+      expect(missing.length).toBeGreaterThan(100);
+      if (buildCnt === 1) {
+        setTimeout(() => {
+          watcher.triggerChanges([buildFile], []);
+        }, 100);
+      }
+    }, function watchEnd () {
+      resolve();
+    });
+
+    console.time('First Build');
+    const { handler, rebuild, close } = ncc(buildFile, {
+      watch: watcher
+    });
+    
+    handler(({ err, code, map, assets, permissions }) => {
+      if (err) return reject(err);
+      buildCnt++;
+      if (buildCnt === 1) {
+        console.timeEnd('First Build');
+      }
+      else {
+        console.timeEnd('Watched Build');
+        close();
+      }
+    });
+    rebuild(() => {
+      console.time('Watched Build');
+    });
+  });
+});

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const ncc = (global.coverage || true) ? require("../src/index") : require("../");
+const ncc = global.coverage ? require("../src/index") : require("../");
+const fs = require('fs');
 
 // Based on the NodeWatchFileSystem class at:
 // - https://github.com/webpack/webpack/blob/master/lib/node/NodeWatchFileSystem.js
@@ -99,8 +100,10 @@ it('Should support custom watch API', async () => {
       expect(files.length).toBeGreaterThan(100);
       expect(dirs.length).toBeGreaterThan(0);
       expect(missing.length).toBeGreaterThan(100);
-      if (buildCnt === 1) {
+      if (buildCnt < 3) {
         setTimeout(() => {
+          // NOTE: We actually have to make the change for the rebuild to happen!
+          fs.writeFileSync(buildFile, fs.readFileSync(buildFile).toString() + '\n');
           watcher.triggerChanges([buildFile], []);
         }, 100);
       }
@@ -121,7 +124,10 @@ it('Should support custom watch API', async () => {
       }
       else {
         console.timeEnd('Watched Build');
+      }
+      if (buildCnt === 3) {
         close();
+        fs.writeFileSync(buildFile, fs.readFileSync(buildFile).toString().slice(0, -2));
       }
     });
     rebuild(() => {

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -90,7 +90,7 @@ class CustomWatchFileSystem {
 	}
 }
 
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 
 it('Should support custom watch API', async () => {
   let buildCnt = 0;


### PR DESCRIPTION
This allows `watch` to be a custom Webpack watcher API.

The example API can be seen in https://github.com/zeit/ncc/compare/hook-watch?expand=1#diff-64e6d0a09767b69fdf92af31d738a902, where a sample watcher is implemented.

The test case performance only kicks in on the third run due to our timestamps being wrong (so taking two runs to sync) in the example case, but a real-world example the correct performance should work on the first run.