### PR TITLE
Fix sourcemap chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.3.7",
+    "@zeit/webpack-asset-relocator-loader": "0.4.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.4.0",
+    "@zeit/webpack-asset-relocator-loader": "0.4.1",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ module.exports = (
       nodeEnv: false,
       minimize: false
     },
-    devtool: sourceMap ? "cheap-source-map" : false,
+    devtool: sourceMap ? "source-map" : false,
     mode: "production",
     target: "node",
     output: {

--- a/src/loaders/empty-loader.js
+++ b/src/loaders/empty-loader.js
@@ -14,7 +14,7 @@ function getPackageBase(id) {
 
 const emptyModules = { 'uglify-js': true };
 
-module.exports = function (input) {
+module.exports = function (input, map) {
   const id = this.resourcePath;
   const pkgBase = getPackageBase(id);
   if (pkgBase) {
@@ -27,5 +27,5 @@ module.exports = function (input) {
       }
     }
   }
-  return input;
+  this.callback(null, input, map);
 };

--- a/src/loaders/uncacheable.js
+++ b/src/loaders/uncacheable.js
@@ -1,4 +1,4 @@
-module.exports = function (input) {
+module.exports = function (input, map) {
   this.cacheable(false);
-  return input;
+  return this.callback(null, input, map);
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -29,5 +29,11 @@
     args: ["build", "-o", "tmp", "--watch", "test/fixtures/no-dep.js"],
     timeout: 500,
     expect: { timeout: true }
+  },
+  {
+    args: ["run", "test/fixtures/fail.ts"],
+    expect (code, stdout, stderr) {
+      return code === 1 && stderr.toString().indexOf('fail.ts:2:1') !== -1;
+    }
   }
 ]

--- a/test/fixtures/fail.ts
+++ b/test/fixtures/fail.ts
@@ -1,0 +1,5 @@
+function x () {
+  throw new Error('Should have correct sourcemap');
+}
+
+x();

--- a/test/fixtures/tsconfig.json
+++ b/test/fixtures/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "es2015"
+  }
+}

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -93,7 +93,7 @@ class CustomWatchFileSystem {
   }
 }
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 it('Should support custom watch API', async () => {
   let buildCnt = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,12 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-"@zeit/webpack-asset-relocator-loader@0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.3.7.tgz#982058d282b0be0c42b01f262dae733223948f7b"
-  integrity sha512-M8JvAk978E4R9QduH9rDGNfOh6YH3lJaQbvkpcBidv0OmXJcLPbb01AW5OheRddT3lwn3Shd1aGjSyJe7QuIaA==
+"@zeit/webpack-asset-relocator-loader@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.4.1.tgz#91945f1a2c72b08851bb96ed9def168d7d5af773"
+  integrity sha512-EAbP51PT1aPryEohgBCOZMz1zGS5VTu+JbQlKB0GqDMuzBN7eqYJmOvr4r0N9LAMbgIKRUpj5l7dKjCozAsgKw==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 JSONStream@^1.3.1, JSONStream@^1.3.4, JSONStream@^1.3.5:
   version "1.3.5"
@@ -11133,6 +11135,11 @@ source-map@~0.1.30:
   integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
+
+sourcemap-codec@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz#c63ea927c029dd6bd9a2b7fa03b3fec02ad56e9f"
+  integrity sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==
 
 sparse-bitfield@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This fixes the loaders to support sourcemap chaining properly, and includes a simple integration test to show the TypeScript sourcemaps are that the right offset.

Tracking Issue: https://github.com/zeit/ncc/issues/353

There will likely be more work to be done here in due course, which we can improve over time (in terms of ensuring the fidelity of the source maps, not their accuracy).

Prerequisite on https://github.com/zeit/webpack-asset-relocator-loader/pull/21.