### PR TITLE
Support debug option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -118,6 +118,8 @@ async function runCmd (argv, stdout, stderr) {
   let args;
   try {
     args = require("arg")({
+      "--debug": Boolean,
+      "-d": "--debug",
       "--external": [String],
       "-e": "--external",
       "--out": String,
@@ -213,6 +215,7 @@ async function runCmd (argv, stdout, stderr) {
       const ncc = require("./index.js")(
         buildFile,
         {
+          debugLog: args["--debug"],
           minify: args["--minify"],
           externals: args["--external"],
           sourceMap: args["--source-map"] || run,

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ module.exports = (
     watch = false,
     v8cache = false,
     quiet = false,
+    debugLog = false
   } = {}
 ) => {
   if (!quiet) {
@@ -146,7 +147,8 @@ module.exports = (
             options: {
               existingAssetNames,
               escapeNonAnalyzableRequires: true,
-              wrapperCompatibility: true
+              wrapperCompatibility: true,
+              debugLog
             }
           }]
         },


### PR DESCRIPTION
This adds a `--debug` flag to the CLI and a `debugLog` option to the API for logging asset emission reasons.

Useful for debugging why assets are being emitted by the build.