### PR TITLE
Update webpack asset relocator loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.4.4",
+    "@zeit/webpack-asset-relocator-loader": "0.4.5",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",


### PR DESCRIPTION
This updates to 0.4.5 with the fix for https://github.com/zeit/ncc/issues/379.

It could be worthwhile to publish a patch release here.