### PR TITLE
Disable v8cache in ncc build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -59,7 +59,7 @@ async function main() {
   // detect unexpected asset emissions from core build
   const unknownAssets = [
     ...Object.keys(cliAssets),
-    ...Object.keys(indexAssets).filter(asset => !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index1.js'),
+    ...Object.keys(indexAssets).filter(asset => !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index1.js' && asset !== 'sourcemap-register.js'),
     ...Object.keys(relocateLoaderAssets),
     ...Object.keys(shebangLoaderAssets),
     ...Object.keys(tsLoaderAssets).filter(asset => !asset.startsWith('lib/') && !asset.startsWith('typescript/lib')),

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,8 +16,7 @@ async function main() {
     {
       filename: "cli.js",
       externals: ["./index.js"],
-      minify: true,
-      v8cache: true
+      minify: true
     }
   );
 
@@ -30,33 +29,31 @@ async function main() {
       // chokidar, which is quite convenient
       externals: ["chokidar"],
       filename: "index.js",
-      minify: true,
-      v8cache: true
+      minify: true
     }
   );
 
   const { code: relocateLoader, assets: relocateLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/relocate-loader",
-    { filename: "relocate-loader.js", minify: true, v8cache: true }
+    { filename: "relocate-loader.js", minify: true }
   );
 
   const { code: shebangLoader, assets: shebangLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/shebang-loader",
-    { filename: "shebang-loader.js", minify: true, v8cache: true }
+    { filename: "shebang-loader.js", minify: true }
   );
 
   const { code: tsLoader, assets: tsLoaderAssets } = await ncc(
     __dirname + "/../src/loaders/ts-loader",
     {
       filename: "ts-loader.js",
-      minify: true,
-      v8cache: true
+      minify: true
     }
   );
 
   const { code: sourcemapSupport, assets: sourcemapAssets } = await ncc(
     require.resolve("source-map-support/register"),
-    { filename: "sourcemap-register.js", minfiy: true, v8cache: true }
+    { filename: "sourcemap-register.js", minfiy: true }
   );
 
   // detect unexpected asset emissions from core build
@@ -67,25 +64,11 @@ async function main() {
     ...Object.keys(shebangLoaderAssets),
     ...Object.keys(tsLoaderAssets).filter(asset => !asset.startsWith('lib/') && !asset.startsWith('typescript/lib')),
     ...Object.keys(sourcemapAssets)
-  ].filter(asset => !asset.endsWith('.js.cache') && !asset.endsWith('.cache.js'));
+  ];
   if (unknownAssets.length) {
     console.error("New assets are being emitted by the core build");
     console.log(unknownAssets);
   }
-
-  writeFileSync(__dirname + "/../dist/ncc/cli.js.cache", cliAssets["cli.js.cache"].source);
-  writeFileSync(__dirname + "/../dist/ncc/index.js.cache", indexAssets["index.js.cache"].source);
-  writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js.cache", sourcemapAssets["sourcemap-register.js.cache"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js.cache", relocateLoaderAssets["relocate-loader.js.cache"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js.cache", shebangLoaderAssets["shebang-loader.js.cache"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js.cache", tsLoaderAssets["ts-loader.js.cache"].source);
-
-  writeFileSync(__dirname + "/../dist/ncc/cli.js.cache.js", cliAssets["cli.js.cache.js"].source);
-  writeFileSync(__dirname + "/../dist/ncc/index.js.cache.js", indexAssets["index.js.cache.js"].source);
-  writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js.cache.js", sourcemapAssets["sourcemap-register.js.cache.js"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js.cache.js", relocateLoaderAssets["relocate-loader.js.cache.js"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/shebang-loader.js.cache.js", shebangLoaderAssets["shebang-loader.js.cache.js"].source);
-  writeFileSync(__dirname + "/../dist/ncc/loaders/ts-loader.js.cache.js", tsLoaderAssets["ts-loader.js.cache.js"].source);
 
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli, { mode: 0o777 });
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);

--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,7 @@ module.exports = (
 
     if (sourceMap && sourceMapRegister) {
       code = `require('./sourcemap-register.js');` + code;
-      assets['sourcemap-register.js'] = { source: fs.readFileSync(__dirname + "/sourcemap-register.js.cache.js"), permissions: defaultPermissions };
+      assets['sourcemap-register.js'] = { source: fs.readFileSync(__dirname + "/sourcemap-register.js"), permissions: defaultPermissions };
     }
 
     if (shebangMatch) {

--- a/src/sourcemap-register.js
+++ b/src/sourcemap-register.js
@@ -1,3 +1,1 @@
-// note: this file is overriden by `scripts/build`
-// and substituted for the production release
-module.exports = require("source-map-support/register");
+../dist/ncc/sourcemap-register.js

--- a/src/sourcemap-register.js.cache.js
+++ b/src/sourcemap-register.js.cache.js
@@ -1,1 +1,0 @@
-../dist/ncc/sourcemap-register.js.cache.js

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -48,24 +48,19 @@ module.exports =
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(545);
+var _module_1 = __webpack_require__(959);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 545:
-/***/ (function() {
+/***/ 959:
+/***/ (function(__unusedmodule, exports) {
 
-const id = "@module";
-if (id.startsWith('./') || id.startsWith('../')) {
-  const e = new Error('Cannot find module "' + id + '".');
-  e.code = 'MODULE_NOT_FOUND';
-  throw e;
-}
-else {
-  eval("require")(id);
-}
+"use strict";
+
+exports.__esModule = true;
+exports["default"] = {};
 
 
 /***/ })

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -48,24 +48,19 @@ module.exports =
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(545);
+var _module_1 = __webpack_require__(494);
 console.log(_module_1["default"]);
 
 
 /***/ }),
 
-/***/ 545:
-/***/ (function() {
+/***/ 494:
+/***/ (function(__unusedmodule, exports) {
 
-const id = "@module";
-if (id.startsWith('./') || id.startsWith('../')) {
-  const e = new Error('Cannot find module "' + id + '".');
-  e.code = 'MODULE_NOT_FOUND';
-  throw e;
-}
-else {
-  eval("require")(id);
-}
+"use strict";
+
+exports.__esModule = true;
+exports["default"] = {};
 
 
 /***/ })


### PR DESCRIPTION
This resolves https://github.com/zeit/ncc/issues/395 in disabling the v8cache in the ncc self-build.

The underlying issue seems to be that there was a report of a possible v8 cache bug on a specific architecture, so that is enough of an indication of instability for us to rather forgo this minor performance benefit.