### PR TITLE
Disable v8cache on Windows only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -365,7 +365,7 @@ module.exports = (
         map = undefined;
       }
       code =
-        `if (process.pkg) {\n` +
+        `if (process.pkg || require('process').platform === 'win32') {\n` +
           `module.exports=require('./${filename}.cache.js');\n` +
         `} else {\n` +
           `const { readFileSync, writeFileSync } = require('fs'), { Script } = require('vm'), { wrap } = require('module');\n` +

--- a/src/sourcemap-register.js
+++ b/src/sourcemap-register.js
@@ -1,3 +1,0 @@
-// note: this file is overriden by `scripts/build`
-// and substituted for the production release
-module.exports = require("source-map-support/register");


### PR DESCRIPTION
This is an alternative workaround for https://github.com/zeit/ncc/issues/395 given that disabling the v8 cache in https://github.com/zeit/ncc/pull/403 turned out to be such a large performance regression.

Since the bug report came from Azure on Node.js 10, this just disables using the v8cache in Windows only as part of the cache runtime itself.