### PR TITLE
Support multiple entry inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.0",
+    "@zeit/webpack-asset-relocator-loader": "0.5.1",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^0.19.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.0-beta.6",
+    "@zeit/webpack-asset-relocator-loader": "0.5.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,6 @@ See [package-support.md](package-support.md) for some common packages and their 
 
 ```js
 require('@zeit/ncc')('/path/to/input', {
-  // custom filename to use in output (default is "index.js")
-  filename: 'build.js',
   // provide a custom cache path or disable caching
   cache: "./custom/cache/path" | false,
   // externals to leave as requires of the build
@@ -89,7 +87,7 @@ require('@zeit/ncc')('/path/to/input', {
 }).then(({ files, symlinks }) => {
   // files: an object of file names to { source, permissions }
   // symlinks: an object of symlink mappings required for the build
-  // The main build file is located at files[filename]:
+  // The main build file is located at files[input]:
   files['build.js'].source
 })
 ```
@@ -100,8 +98,6 @@ Multiple entry points can be built by providing an object to build. In this case
 require('@zeit/ncc')({
   entry1: '/path/to/input1',
   entry2: '/path/to/input2
-}, {
-  filename: '[name].js' // default
 }).then(({ files, symlinks }) => {
   files['entry1.js'].source
   files['entry1.js.map'].source
@@ -109,8 +105,6 @@ require('@zeit/ncc')({
   // ... assets
 });
 ```
-
-The `filename` option supports all Webpack supported patterns (eg `[name].js`) in the multi-entry case.
 
 When `watch: true` is set, the build object is not a promise, but has the following signature:
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,8 @@ $ ncc build input.js -o dist
 
 Outputs the Node.js compact build of `input.js` into `dist/index.js`.
 
+It is also possible to build multiple files in a code-splitting build by passing additional inputs.
+
 ### Execution Testing
 
 For testing and debugging, a file can be built into a temporary directory and executed with full source maps support with the command:

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,8 @@ See [package-support.md](package-support.md) for some common packages and their 
 
 ```js
 require('@zeit/ncc')('/path/to/input', {
+  // custom filename to use in output (default is "index.js")
+  filename: 'build.js',
   // provide a custom cache path or disable caching
   cache: "./custom/cache/path" | false,
   // externals to leave as requires of the build
@@ -82,12 +84,31 @@ require('@zeit/ncc')('/path/to/input', {
   v8cache: false, // default
   quiet: false, // default
   debugLog = false // default
-}).then(({ code, map, assets }) => {
-  console.log(code);
-  // Assets is an object of asset file names to { source, permissions, symlinks }
-  // expected relative to the output code (if any)
+}).then(({ output }) => {
+  // Output is an object of file names to { source, permissions } | string
+  // Where string entries represent symlinks to other files, referenced relatively.
+  // The main build file is located at output[filename].
+  output['build.js'].source
 })
 ```
+
+Multiple entry points can be built by providing an object to build. In this case the output returned is an array of `{ code, map }` pairs:
+
+```js
+require('@zeit/ncc')({
+  entry1: '/path/to/input1',
+  entry2: '/path/to/input2
+}, {
+  filename: '[name].js' // default
+}).then(({ output }) => {
+  output['entry1.js'].source
+  output['entry1.js.map'].source
+  output['entry2.js'].source
+  // ... assets
+});
+```
+
+The `filename` option supports all Webpack supported patterns (eg `[name].js`) in the multi-entry case.
 
 When `watch: true` is set, the build object is not a promise, but has the following signature:
 

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,8 @@ require('@zeit/ncc')('/path/to/input', {
 }).then(({ files, symlinks }) => {
   // files: an object of file names to { source, permissions }
   // symlinks: an object of symlink mappings required for the build
-  // The main build file is located at files[input]:
-  files['build.js'].source
+  // The main file is located at 'index.js':
+  files['index.js'].source
 })
 ```
 
@@ -99,6 +99,7 @@ require('@zeit/ncc')({
   entry1: '/path/to/input1',
   entry2: '/path/to/input2
 }).then(({ files, symlinks }) => {
+  // named entry points are available at their names:
   files['entry1.js'].source
   files['entry1.js.map'].source
   files['entry2.js'].source

--- a/readme.md
+++ b/readme.md
@@ -86,15 +86,15 @@ require('@zeit/ncc')('/path/to/input', {
   v8cache: false, // default
   quiet: false, // default
   debugLog = false // default
-}).then(({ output }) => {
-  // Output is an object of file names to { source, permissions } | string
-  // Where string entries represent symlinks to other files, referenced relatively.
-  // The main build file is located at output[filename].
-  output['build.js'].source
+}).then(({ files, symlinks }) => {
+  // files: an object of file names to { source, permissions }
+  // symlinks: an object of symlink mappings required for the build
+  // The main build file is located at files[filename]:
+  files['build.js'].source
 })
 ```
 
-Multiple entry points can be built by providing an object to build. In this case the output returned is an array of `{ code, map }` pairs:
+Multiple entry points can be built by providing an object to build. In this case, those files are avaiable as additional output files:
 
 ```js
 require('@zeit/ncc')({
@@ -102,10 +102,10 @@ require('@zeit/ncc')({
   entry2: '/path/to/input2
 }, {
   filename: '[name].js' // default
-}).then(({ output }) => {
-  output['entry1.js'].source
-  output['entry1.js.map'].source
-  output['entry2.js'].source
+}).then(({ files, symlinks }) => {
+  files['entry1.js'].source
+  files['entry1.js.map'].source
+  files['entry2.js'].source
   // ... assets
 });
 ```
@@ -118,7 +118,7 @@ When `watch: true` is set, the build object is not a promise, but has the follow
 {
   // handler re-run on each build completion
   // watch errors are reported on "err"
-  handler (({ err, code, map, assets }) => { ... })
+  handler (({ err, files, symlinks }) => { ... })
   // handler re-run on each rebuild start
   rebuild (() => {})
   // close the watcher

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,10 +16,9 @@ async function main() {
   }
 
   const { files: cliFiles } = await ncc(
-    __dirname + "/../src/cli",
+    { 'cli': __dirname + "/../src/cli" },
     {
       externals: ["./index.js"],
-      filename: "cli.js",
       minify: true,
       v8cache: true
     }
@@ -27,14 +26,13 @@ async function main() {
   checkUnknownAssets('cli', assetList(cliFiles));
 
   const { files: indexFiles } = await ncc(
-    __dirname + "/../src/index",
+    { 'index': __dirname + "/../src/index" },
     {
       // we dont care about watching, so we don't want
       // to bundle it. even if we did want watching and a bigger
       // bundle, webpack (and therefore ncc) cannot currently bundle
       // chokidar, which is quite convenient
       externals: ["chokidar"],
-      filename: "index.js",
       minify: true,
       v8cache: true
     }
@@ -42,30 +40,26 @@ async function main() {
   checkUnknownAssets('index', assetList(indexFiles).filter(asset => !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index.js'));
 
   const { files: relocateLoaderFiles } = await ncc(
-    __dirname + "/../src/loaders/relocate-loader",
-    { filename: "relocate-loader.js", minify: true, v8cache: true }
+    { 'relocate-loader': __dirname + "/../src/loaders/relocate-loader",},
+    { minify: true, v8cache: true }
   );
   checkUnknownAssets('relocate-loader', assetList(relocateLoaderFiles));
 
   const { files: shebangLoaderFiles } = await ncc(
-    __dirname + "/../src/loaders/shebang-loader",
-    { filename: "shebang-loader.js", minify: true, v8cache: true }
+    { 'shebang-loader': __dirname + "/../src/loaders/shebang-loader" },
+    { minify: true, v8cache: true }
   );
   checkUnknownAssets('shebang-loader', assetList(shebangLoaderFiles));
 
   const { files: tsLoaderFiles } = await ncc(
-    __dirname + "/../src/loaders/ts-loader",
-    {
-      filename: "ts-loader.js",
-      minify: true,
-      v8cache: true
-    }
+    { 'ts-loader': __dirname + "/../src/loaders/ts-loader" },
+    { minify: true, v8cache: true }
   );
   checkUnknownAssets('ts-loader', assetList(tsLoaderFiles).filter(asset => !asset.startsWith('lib/') && !asset.startsWith('typescript/lib')));
 
   const { files: sourceMapSupportFiles } = await ncc(
-    require.resolve("source-map-support/register"),
-    { filename: "sourcemap-register.js", minfiy: true, v8cache: true }
+    { 'sourcemap-register': require.resolve("source-map-support/register") },
+    { minifiy: true, v8cache: true }
   );
   checkUnknownAssets('source-map-support/register', assetList(sourceMapSupportFiles));
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -15,7 +15,7 @@ async function main() {
     unlinkSync(file);
   }
 
-  const { output: cliFiles } = await ncc(
+  const { files: cliFiles } = await ncc(
     __dirname + "/../src/cli",
     {
       externals: ["./index.js"],
@@ -26,7 +26,7 @@ async function main() {
   );
   checkUnknownAssets('cli', assetList(cliFiles));
 
-  const { output: indexFiles } = await ncc(
+  const { files: indexFiles } = await ncc(
     __dirname + "/../src/index",
     {
       // we dont care about watching, so we don't want
@@ -41,19 +41,19 @@ async function main() {
   );
   checkUnknownAssets('index', assetList(indexFiles).filter(asset => !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index.js'));
 
-  const { output: relocateLoaderFiles } = await ncc(
+  const { files: relocateLoaderFiles } = await ncc(
     __dirname + "/../src/loaders/relocate-loader",
     { filename: "relocate-loader.js", minify: true, v8cache: true }
   );
   checkUnknownAssets('relocate-loader', assetList(relocateLoaderFiles));
 
-  const { output: shebangLoaderFiles } = await ncc(
+  const { files: shebangLoaderFiles } = await ncc(
     __dirname + "/../src/loaders/shebang-loader",
     { filename: "shebang-loader.js", minify: true, v8cache: true }
   );
   checkUnknownAssets('shebang-loader', assetList(shebangLoaderFiles));
 
-  const { output: tsLoaderFiles } = await ncc(
+  const { files: tsLoaderFiles } = await ncc(
     __dirname + "/../src/loaders/ts-loader",
     {
       filename: "ts-loader.js",
@@ -63,7 +63,7 @@ async function main() {
   );
   checkUnknownAssets('ts-loader', assetList(tsLoaderFiles).filter(asset => !asset.startsWith('lib/') && !asset.startsWith('typescript/lib')));
 
-  const { output: sourceMapSupportFiles } = await ncc(
+  const { files: sourceMapSupportFiles } = await ncc(
     require.resolve("source-map-support/register"),
     { filename: "sourcemap-register.js", minfiy: true, v8cache: true }
   );

--- a/src/cli.js
+++ b/src/cli.js
@@ -258,7 +258,7 @@ async function runCmd (argv, stdout, stderr) {
         if (run) {
           // find node_modules
           const root = resolve('/node_modules');
-          const buildFile = eval("require.resolve")(args._[1]);
+          const buildFile = resolve(args._[1]);
           let nodeModulesDir = dirname(buildFile) + "/node_modules";
           do {
             if (nodeModulesDir === root) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { resolve, relative, dirname, sep, basename, extname } = require("path");
+const { resolve, relative, dirname, sep } = require("path");
 const glob = require("glob");
 const rimraf = require("rimraf");
 const crypto = require("crypto");
@@ -185,16 +185,7 @@ async function runCmd (argv, stdout, stderr) {
 
     // fallthrough
     case "build":
-      let buildFiles;
-      if (runArgs) {
-        buildFiles = resolve(args._[1]);
-      }
-      else {
-        buildFiles = Object.create(null);
-        args._.slice(1).forEach(file => {
-          buildFiles[basename(file.substr(0, file.length - extname(file).length))] = resolve(file);
-        });
-      }
+      const buildFiles = runArgs ? resolve(args._[1]) : args._.slice(1);
 
       let startTime = Date.now();
       let ps;

--- a/src/cli.js
+++ b/src/cli.js
@@ -213,7 +213,7 @@ async function runCmd (argv, stdout, stderr) {
         }
       );
 
-      async function handler ({ err, output }) {
+      async function handler ({ err, files, symlinks }) {
         // handle watch errors
         if (err) {
           stderr.write(err + '\n');
@@ -232,20 +232,24 @@ async function runCmd (argv, stdout, stderr) {
           ))
         );
 
-        for (const filename of Object.keys(output)) {
-          const file = output[filename];
+        for (const filename of Object.keys(files)) {
+          const file = files[filename];
           const filePath = outDir + "/" + filename;
           mkdirp.sync(dirname(filePath));
-          if (typeof file === 'string')
-            symlinkSync(file, filePath);
-          else
-            writeFileSync(filePath, file.source, { mode: file.permissions });
+          writeFileSync(filePath, file.source, { mode: file.permissions });
+        }
+
+        for (const filename of Object.keys(symlinks)) {
+          const file = symlinks[filename];
+          const filePath = outDir + "/" + filename;
+          mkdirp.sync(dirname(filePath));
+          symlinkSync(file, filePath);
         }
 
         if (!quiet) {
           stdout.write(
             renderSummary(
-              output,
+              files,
               run ? "" : relative(process.cwd(), outDir),
               Date.now() - startTime,
             ) + '\n'

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,7 +64,7 @@ function renderSummary(files, outDir, buildTime) {
     totalSize += assetSize;
     if (file.length > maxAssetNameLength) maxAssetNameLength = file.length;
   }
-  const orderedAssets = Object.keys(files).sort((a, b) => {
+  const orderedAssets = Object.keys(files).filter(file => typeof files[file] === 'object').sort((a, b) => {
     if ((a.startsWith('asset/') || b.startsWith('asset/')) &&
         !(a.startsWith('asset/') && b.startsWith('asset/')))
       return a.startsWith('asset/') ? 1 : -1;
@@ -75,12 +75,12 @@ function renderSummary(files, outDir, buildTime) {
 
   let output = "",
     first = true;
-  for (const asset of orderedAssets) {
+  for (const file of orderedAssets) {
     if (first) first = false;
     else output += "\n";
-    output += `${fileSizes[asset]
+    output += `${fileSizes[file]
       .toString()
-      .padStart(sizePadding, " ")}kB  ${outDir}${asset}`;
+      .padStart(sizePadding, " ")}kB  ${outDir}${file}`;
   }
 
   output += `\n${totalSize}kB  [${buildTime}ms] - ncc ${nccVersion}`;

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ module.exports = (
   }
   if (!quiet) {
     console.log(`ncc: Version ${nccVersion}`);
-    console.log(`ncc: Compiling file${typeof entry === 'object' && Object.keys(entry).length > 1 ? 's' : ''} ${Object.values(processedEntry).join(', ')}`);
+    console.log(`ncc: Compiling file${Object.keys(processedEntry).length > 1 ? 's' : ''} ${Object.values(processedEntry).join(', ')}`);
   }
   // How to handle for multi-entry case?
   process.env.TYPESCRIPT_LOOKUP_PATH = Object.values(processedEntry)[0];

--- a/src/index.js
+++ b/src/index.js
@@ -392,7 +392,7 @@ module.exports = (
       }
 
       files[filename].source = code;
-      if (sourceMap)
+      if (sourceMap && map)
         files[filename + '.map'].source = JSON.stringify(map);
     }
 
@@ -411,7 +411,7 @@ function getFlatFiles(mfsData, output, getAssetPermissions, curBase = "") {
     else if (!curPath.endsWith("/")) {
       output[curPath.substr(1)] = {
         source: mfsData[path],
-        permissions: getAssetPermissions(curPath.substr(1))
+        permissions: getAssetPermissions(curPath.substr(1)) || defaultPermissions
       };
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,13 @@
 const resolve = require("resolve");
 const fs = require("graceful-fs");
 const crypto = require("crypto");
-const { sep, join, dirname } = require("path");
+const { join, dirname } = require("path");
 const webpack = require("webpack");
 const MemoryFS = require("memory-fs");
 const terser = require("terser");
 const tsconfigPaths = require("tsconfig-paths");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const shebangRegEx = require('./utils/shebang');
-const { pkgNameRegEx } = require("./utils/get-package-base");
 const nccCacheDir = require("./utils/ncc-cache-dir");
 const { version: nccVersion } = require('../package.json');
 
@@ -48,8 +47,8 @@ module.exports = (
   } = {}
 ) => {
   if (!filename)
-    filename = entry instanceof Array && entry.length > 1 ? "[name].js" : "index.js";
-  const resolvedEntry = resolve.sync(typeof entry === 'string' ? entry : Object.values(entry)[0]);
+    filename = typeof entry === 'object' && Object.keys(entry).length > 1 ? "[name].js" : "index.js";
+  const resolvedEntry = resolve.sync(typeof entry === 'string' ? entry : Object.values(entry)[0], { basedir: process.cwd() });
   if (!quiet) {
     console.log(`ncc: Version ${nccVersion}`);
     console.log(`ncc: Compiling file${typeof entry === 'object' && Object.keys(entry).length > 1 ? 's' : ''} ${typeof entry === 'object' ? Object.values(entry).map(name => resolve.sync(name)).join(', ') : resolvedEntry}`);

--- a/src/index.js
+++ b/src/index.js
@@ -309,11 +309,12 @@ module.exports = (
 
   function finalizeHandler (stats) {
     const files = Object.create(null);
+    const symlinks = Object.create(null);
     getFlatFiles(mfs.data, files, relocateLoader.getAssetPermissions);
     for (const [key, value] of Object.entries(relocateLoader.getSymlinks())) {
       const resolved = join(dirname(key), value);
       if (resolved in files && key in files === false)
-        files[key] = value;
+        symlinks[key] = value;
     }
 
     for (const chunk of stats.compilation.chunks) {
@@ -395,7 +396,7 @@ module.exports = (
         files[filename + '.map'].source = JSON.stringify(map);
     }
 
-    return { output: files };
+    return { files, symlinks };
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const resolve = require("resolve");
 const fs = require("graceful-fs");
 const crypto = require("crypto");
-const { join, dirname } = require("path");
+const { join, dirname, resolve: pathResolve, basename, extname } = require("path");
 const webpack = require("webpack");
 const MemoryFS = require("memory-fs");
 const terser = require("terser");
@@ -48,6 +48,13 @@ module.exports = (
 ) => {
   if (!filename)
     filename = typeof entry === 'object' && Object.keys(entry).length > 1 ? "[name].js" : "index.js";
+  if (entry instanceof Array) {
+    const objEntry = Object.create(null);
+    entry.forEach(file => {
+      objEntry[basename(file.substr(0, file.length - extname(file).length))] = pathResolve(file);
+    });
+    entry = objEntry;
+  }
   const resolvedEntry = resolve.sync(typeof entry === 'string' ? entry : Object.values(entry)[0], { basedir: process.cwd() });
   if (!quiet) {
     console.log(`ncc: Version ${nccVersion}`);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,8 +21,8 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
         'externaltest': 'externalmapped'
       }
     }).then(
-      async ({ code, assets }) => {
-        const actual = code
+      async ({ output }) => {
+        const actual = output['index.js'].source
           .trim()
           // Windows support
           .replace(/\r/g, "");

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,8 +21,8 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
         'externaltest': 'externalmapped'
       }
     }).then(
-      async ({ output }) => {
-        const actual = output['index.js'].source
+      async ({ files }) => {
+        const actual = files['index.js'].source
           .trim()
           // Windows support
           .replace(/\r/g, "");

--- a/test/multi-entry.test.js
+++ b/test/multi-entry.test.js
@@ -1,0 +1,16 @@
+const ncc = global.coverage ? require("../src/index") : require("../");
+const path = require('path');
+const assert = require('assert');
+
+jest.setTimeout(30000);
+
+it('Should support multiple entry points', async () => {
+  const { output } = await ncc({
+    twilio: path.resolve('./test/integration/twilio.js'),
+    leveldown: path.resolve('./test/integration/leveldown.js')
+  }, {
+    filename: '[name].js'
+  });
+
+  assert.strictEqual(Object.keys(output).length, 4);
+});

--- a/test/multi-entry.test.js
+++ b/test/multi-entry.test.js
@@ -5,10 +5,10 @@ const assert = require('assert');
 jest.setTimeout(30000);
 
 it('Should support multiple entry points', async () => {
-  const { output } = await ncc({
+  const { files } = await ncc({
     twilio: path.resolve('./test/integration/twilio.js'),
     leveldown: path.resolve('./test/integration/leveldown.js')
   });
 
-  assert.strictEqual(Object.keys(output).length, 4);
+  assert.strictEqual(Object.keys(files).length, 4);
 });

--- a/test/multi-entry.test.js
+++ b/test/multi-entry.test.js
@@ -8,8 +8,6 @@ it('Should support multiple entry points', async () => {
   const { output } = await ncc({
     twilio: path.resolve('./test/integration/twilio.js'),
     leveldown: path.resolve('./test/integration/leveldown.js')
-  }, {
-    filename: '[name].js'
   });
 
   assert.strictEqual(Object.keys(output).length, 4);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,10 +1225,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.5.0-beta.6":
-  version "0.5.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.0-beta.6.tgz#c25c8335bb8f836a90249196538b150c7cbe9228"
-  integrity sha512-pNV28syb5ebsGKKYwnitm4VQv+cbKIx8K5wBlX5WGbhhN6jw5vav3pYKLENdx6g/Cxy91ofGssL0CSzASXWkiw==
+"@zeit/webpack-asset-relocator-loader@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.1.tgz#796e454c18fefa1b08be322c7908e8fa2294ea3e"
+  integrity sha512-GbFVKSIru5vBF89Z6pSdc5qlCt5uXOsQM3/3ojx+oiqTqWY2mnUsVcJBOq8Xeyq0EPumClfVtdbFLuFCW7Yc9Q==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
This implements #113 supporting an object form for `entry`:

```js
ncc({
  entry1: '/path/to/entry1.js',
  entry2: '/path/to/entry2.js'
})
```

where the separate entry points will have shared chunks and therefore shared dependency instances meaning any shared dependency state will be maintained as shared state between the entry points (no more instancing issues!).

In addition `filename` supports the Webpack `[name]` patterns now.

I also changed the output API to support this to an object with an `output` property (this is what we did in Rollup!), where the output is an object mapping file path strings to file entries or symlinks:

```
ncc().then(({ files }) => {
  console.log(files['index.js'].source);
});
```

I'm not fixed to this API thought at all, so please do share your feedback on this if you think any variations may be better.

This PR is passing all tests tests when combined with the PR at https://github.com/zeit/webpack-asset-relocator-loader/pull/43, and https://github.com/zeit/webpack-asset-relocator-loader/pull/44.

Closes #113