### PR TITLE
Fix regression where CLI doesnt build index.js

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -185,7 +185,7 @@ async function runCmd (argv, stdout, stderr) {
 
     // fallthrough
     case "build":
-      const buildFiles = runArgs ? resolve(args._[1]) : args._.slice(1);
+      const buildFiles = (runArgs || args._.length === 2) ? resolve(args._[1]) : args._.slice(1);
 
       let startTime = Date.now();
       let ps;

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,6 +4,12 @@
     expect: { code: 0 }
   },
   {
+    args: ["build", "test/integration/test.ts", "-o", "tmp"],
+    expect (code, stdout, stderr) {
+      return stdout.toString().indexOf('tmp/index.js') !== -1;
+    }
+  },
+  {
     args: ["run", "--v8-cache", "test/integration/test.ts"],
     expect: { code: 0 }
   },


### PR DESCRIPTION
Just noticed this regression on the CLI from the multi-entry work - when running `ncc build x` it was outputting `dist/x.js` instead of `dist/index.js`.

The fix is to ensure we pass a string input from the CLI when there is a single file, and an array when there is more than one.