### PR TITLE
Update asset loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^2.2.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.1",
+    "@zeit/webpack-asset-relocator-loader": "0.5.3",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.1.tgz#796e454c18fefa1b08be322c7908e8fa2294ea3e"
-  integrity sha512-GbFVKSIru5vBF89Z6pSdc5qlCt5uXOsQM3/3ojx+oiqTqWY2mnUsVcJBOq8Xeyq0EPumClfVtdbFLuFCW7Yc9Q==
+"@zeit/webpack-asset-relocator-loader@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.3.tgz#7450ac05c92d2ba82c7c9bcdd9dce53802687e18"
+  integrity sha512-+SDL6X1FUCISvsUaP/MeI+NGZ2LXItjtwlWSfcvbHY9LfJHxjQg0GTwW6nv7VrOY9VAW1d7XuXd7kXU/d6j72A==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
Updates to release:
* https://github.com/zeit/webpack-asset-relocator-loader/releases/tag/0.5.2.
* https://github.com/zeit/webpack-asset-relocator-loader/releases/tag/0.5.3