### PR TITLE
Example workaround for `@google-cloud/vision`

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
     "webpack": "5.0.0-alpha.12",
     "when": "^3.7.8",
     "yoga-layout": "^1.9.3"
+  },
+  "dependencies": {
+    "@google-cloud/vision": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "fontkit": "^1.7.7",
     "get-folder-size": "^2.0.0",
     "glob": "^7.1.3",
+    "google-proto-files": "1.0.1",
     "got": "^9.3.2",
     "graceful-fs": "^4.1.15",
     "graphql": "^14.0.2",

--- a/test/integration/google-cloud-vision.js
+++ b/test/integration/google-cloud-vision.js
@@ -1,0 +1,1 @@
+require('@google-cloud/vision')

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,11 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-0.3.1.tgz#f641e6d944a8e0a05ee0cb1091dfa60089becdba"
   integrity sha512-QzB0/IMvB0eFxFK7Eqh+bfC8NLv3E9ScjWQrPOk6GgfNroxcVITdTlT8NRsRrcp5+QQJVPLkRqKG0PUdaWXmHw==
 
+"@google-cloud/promisify@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-1.0.0.tgz#1ae99ab8dd36807ee9923a81f8c6bc9159025fe9"
+  integrity sha512-B1wYzEqvM71QQgzc47xH3np40dxT17G76gMYew0q/fSwU/iWu7nNfxOU8Ataormee5j/n27G1muKU85LRdecww==
+
 "@google-cloud/storage@^1.6.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-1.7.0.tgz#07bff573d92d5c294db6a04af246688875a8f74b"
@@ -391,6 +396,16 @@
     stream-events "^1.0.1"
     through2 "^2.0.0"
     xdg-basedir "^3.0.0"
+
+"@google-cloud/vision@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/vision/-/vision-1.1.1.tgz#84f2bf825b849acd2fb7d604f7ed1f78dfdec297"
+  integrity sha512-khhyUx5XmVRoUZYjQvkNguwjAgylJenSN9IwWX3L+lhPanvg1HYw2jeATLrBHbP77SzFCbzJ3+IxTR+yTjttmA==
+  dependencies:
+    "@google-cloud/promisify" "^1.0.0"
+    google-gax "^1.0.0"
+    is "^3.2.1"
+    protobufjs "^6.8.6"
 
 "@grpc/grpc-js@^0.3.0":
   version "0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5248,6 +5248,14 @@ google-p12-pem@^2.0.0:
   dependencies:
     node-forge "^0.8.0"
 
+google-proto-files@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/google-proto-files/-/google-proto-files-1.0.1.tgz#029d9ad5ac9b65925a018dfe5ff0561113e02356"
+  integrity sha512-s5/pNQjweaPvCbH7uiTbKjrBye8jyM5pP+ZNj7P4j/t/VkV+DZua+SkZPrVGYy+cIwRBxTXrAptYBzpNn4DQAA==
+  dependencies:
+    protobufjs "^6.8.0"
+    walkdir "^0.4.0"
+
 google-proto-files@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/google-proto-files/-/google-proto-files-0.18.0.tgz#5be91bac15b38dbeae00393b0e47b9acb6c51cf2"


### PR DESCRIPTION
The failure is similar to the last one:

```
Error: The include `google/cloud/vision/v1p4beta1/geometry.proto` was not found.
    at Function._findIncludePath (/tmp/4e497625c085ff0b559dc241c685febd/index.js:88738:19)
    at GoogleProtoFilesRoot.resolvePath (/tmp/4e497625c085ff0b559dc241c685febd/index.js:88726:37)
    at process (/tmp/node_modules/protobufjs/src/root.js:112:1)
    at fetch (/tmp/node_modules/protobufjs/src/root.js:166:1)
    at GoogleProtoFilesRoot.load (/tmp/node_modules/protobufjs/src/root.js:194:1)
    at GoogleProtoFilesRoot.loadSync (/tmp/node_modules/protobufjs/src/root.js:235:1)
    at Object.loadSync (/tmp/node_modules/protobufjs/src/index-light.js:69:1)
    at module.exports.module.exports.apiVersion (/tmp/4e497625c085ff0b559dc241c685febd/index.js:36443:29)
    at Object.<anonymous> (/tmp/node_modules/@google-cloud/vision/src/index.js:59:1)
    at __webpack_require__ (/webpack/bootstrap:19:1)
```

But unfortunately a completely different unknown reason for now.