### PR TITLE
Use isArray check for `externals`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ module.exports = (
 
   const externalMap = new Map();
 
-  if (externals instanceof Array)
+  if (Array.isArray(externals))
     externals.forEach(external => externalMap.set(external, external));
   else if (typeof externals === 'object')
     Object.keys(externals).forEach(external => externalMap.set(external, externals[external]));


### PR DESCRIPTION
We support both object and array forms for externals. In the array case the check of `instanceof Array` is failing for Next.js likely due to the use of a separate context for the configuration than ncc itself.

This fixes that behaviour by using `isArray`.