### PR TITLE
Fixup windows build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -370,15 +370,12 @@ module.exports = (
         map = undefined;
       }
       code =
-        `if (process.pkg || require('process').platform === 'win32') {\n` +
-          `module.exports=require('./${filename}.cache.js');\n` +
-        `} else {\n` +
-          `const { readFileSync, writeFileSync } = require('fs'), { Script } = require('vm'), { wrap } = require('module');\n` +
-          `const source = readFileSync(__dirname + '/${filename}.cache.js', 'utf-8'), cachedData = readFileSync(__dirname + '/${filename}.cache');\n` +
-          `const script = new Script(wrap(source), { cachedData });\n` +
-          `(script.runInThisContext())(exports, require, module, __filename, __dirname);\n` +
-          `process.on('exit', () => { try { writeFileSync(__dirname + '/${filename}.cache', script.createCachedData()); } catch(e) {} });\n` +
-        `}`;
+        `const { readFileSync, writeFileSync } = require('fs'), { Script } = require('vm'), { wrap } = require('module');\n` +
+        `const source = readFileSync(__dirname + '/${filename}.cache.js', 'utf-8');\n` +
+        `const cachedData = !process.pkg && require('process').platform !== 'win32' && readFileSync(__dirname + '/${filename}.cache');\n` +
+        `const script = new Script(wrap(source), cachedData ? { cachedData } : {});\n` +
+        `(script.runInThisContext())(exports, require, module, __filename, __dirname);\n` +
+        `if (cachedData) process.on('exit', () => { try { writeFileSync(__dirname + '/${filename}.cache', script.createCachedData()); } catch(e) {} });\n`;
     }
 
     if (sourceMap && sourceMapRegister) {


### PR DESCRIPTION
This fixes up the Windows build, which regressed in https://github.com/zeit/ncc/commit/67ebbf1abac29ec30652099056a72ab0939ce8bd since the `require.main === module` check was broken by that adjustment.

This retains the `require.main === module` check by still spawning a separate process in the Windows case (just not using the v8cache).