### PR TITLE
Update to webpack-asset-relocator-loader 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^2.2.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.5",
+    "@zeit/webpack-asset-relocator-loader": "0.5.6",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,8 @@ require('@zeit/ncc')('/path/to/input', {
   cache: "./custom/cache/path" | false,
   // externals to leave as requires of the build
   externals: ["externalpackage"],
+  // directory outside of which never to emit assets
+  filterAssetBase: process.cwd(), // default
   minify: false, // default
   sourceMap: false, // default
   sourceMapBasePrefix: '../' // default treats sources as output-relative

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ module.exports = (
     sourceMapBasePrefix = '../',
     watch = false,
     v8cache = false,
+    filterAssetBase = process.cwd(),
     quiet = false,
     debugLog = false
   } = {}
@@ -154,6 +155,7 @@ module.exports = (
           }, {
             loader: eval('__dirname + "/loaders/relocate-loader.js"'),
             options: {
+              filterAssetBase,
               existingAssetNames,
               escapeNonAnalyzableRequires: true,
               wrapperCompatibility: true,

--- a/test/integration/npm.js
+++ b/test/integration/npm.js
@@ -1,5 +1,6 @@
 const npm = require('npm');
 const install = require('npm/lib/install');
+const rimraf = require('rimraf');
 
 npm.load((err) => {
   if (err) {
@@ -13,4 +14,5 @@ npm.load((err) => {
   }
   const args = [`lodash@4.1.17`];
   install('./asdf', args, () => {});
+  rimraf.sync('./asdf');
 });

--- a/test/unit/externals/output-coverage.js
+++ b/test/unit/externals/output-coverage.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/externals/output.js
+++ b/test/unit/externals/output.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/runtime-notfound/output-coverage.js
+++ b/test/unit/runtime-notfound/output-coverage.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/runtime-notfound/output.js
+++ b/test/unit/runtime-notfound/output.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/shebang/output-coverage.js
+++ b/test/unit/shebang/output-coverage.js
@@ -30,6 +30,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/shebang/output.js
+++ b/test/unit/shebang/output.js
@@ -30,6 +30,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/ts-decl/output-coverage.js
+++ b/test/unit/ts-decl/output-coverage.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -29,6 +29,7 @@ module.exports =
 /******/ 	}
 /******/
 /******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
 /******/
 /******/ 	// the startup function
 /******/ 	function startup() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.5.tgz#c50543e479feb642c68356f0216759325544b507"
-  integrity sha512-QrAytM+XznVV1q3E1nkg95ASYka2kz/OEoDTZ/GeDRWihYmk8iyqqI4XpzystIYOc4vi7jXkHmuQutscs6PgAw==
+"@zeit/webpack-asset-relocator-loader@0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.6.tgz#adfa4d3b0cc740aee57950e29efbaf2d40dc15c7"
+  integrity sha512-fK1zeOB67cob8eBkhgN+OKU5HsEe/XmKq1As6SVzmy1BxyWVpdUIIDeQtRHZM6veG/j7/a5XOeP/VpOOz1ingw==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
This upgrades to the latest release at https://github.com/zeit/webpack-asset-relocator-loader/releases/tag/0.5.6.

This will fix #435 and fix #440, completing the now-node upgrade bug fixes outlined in #434.

In addition, we expose the `filterAssetBase` option as an ncc option - this will allow fixing the 08 asset build in now-node by setting this path to the path to the application folder being built.