### PR TITLE
Update to webpack-asset-relocator-loader@0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^2.2.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.6",
+    "@zeit/webpack-asset-relocator-loader": "0.5.7",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ module.exports = (
               }
             );
           });
-          compiler.hooks.compilation.tap("relocate-loader", relocateLoader.initAssetPermissionsCache);
+          compiler.hooks.compilation.tap("relocate-loader", compilation => relocateLoader.initAssetCache(compilation));
           compiler.hooks.watchRun.tap("ncc", () => {
             if (rebuildHandler)
               rebuildHandler();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.5.6":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.6.tgz#adfa4d3b0cc740aee57950e29efbaf2d40dc15c7"
-  integrity sha512-fK1zeOB67cob8eBkhgN+OKU5HsEe/XmKq1As6SVzmy1BxyWVpdUIIDeQtRHZM6veG/j7/a5XOeP/VpOOz1ingw==
+"@zeit/webpack-asset-relocator-loader@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.7.tgz#ee0872ce53ef0085073233c7220d09b40ee2502a"
+  integrity sha512-Udps+rrlqKFVL7/CIvGdi/auCNAjvODSqgbnyiEfKAqokDGZExiarjWwMsVzKBtzHrqVWg7glFl2mTI5hqPpJw==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
Release - https://github.com/zeit/webpack-asset-relocator-loader/releases/tag/0.5.7.

Fixes an important cache bug with the new public path emission in the Webpack template, where the public path wasn't being emitted when all assets of the build hit the cache.