### PR TITLE
ncc internal typescript build bug workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ncc": "./dist/ncc/cli.js"
   },
   "scripts": {
-    "build": "node scripts/build",
+    "build": "node scripts/build && curl -L https://unpkg.com/@zeit/ncc@0.18/dist/ncc/loaders/ts-loader.js.cache.js > dist/ncc/loaders/ts-loader.js.cache.js",
     "build-test-binary": "cd test/binary && node-gyp rebuild && cp build/Release/hello.node ../integration/hello.node",
     "codecov": "codecov",
     "test": "npm run build-test-binary && npm run build && node --expose-gc --max_old_space_size=3072 node_modules/.bin/jest",
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^2.2.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.5.7",
+    "@zeit/webpack-asset-relocator-loader": "0.6.1",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.7.tgz#ee0872ce53ef0085073233c7220d09b40ee2502a"
-  integrity sha512-Udps+rrlqKFVL7/CIvGdi/auCNAjvODSqgbnyiEfKAqokDGZExiarjWwMsVzKBtzHrqVWg7glFl2mTI5hqPpJw==
+"@zeit/webpack-asset-relocator-loader@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.6.1.tgz#1cd8f268a2a981acafc657ce8482183bbd46a51b"
+  integrity sha512-ywwDEJEV9cNk+PjGmUWgbewmy9f9G6UtRrC9xrKlrO7sHeU48aPwVPBp1vgqc2h7Zfjbmfb9jZ2pGAEIBclNvg==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
This provides a workaround for https://github.com/zeit/ncc/issues/435 by using the previous TypeScript build.

Hopefully we can get a proper bug fix in soon as well to avoid this workaround.