### PR TITLE
Fix TypeScript builtin without workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ncc": "./dist/ncc/cli.js"
   },
   "scripts": {
-    "build": "node scripts/build && curl -L https://unpkg.com/@zeit/ncc@0.18/dist/ncc/loaders/ts-loader.js.cache.js > dist/ncc/loaders/ts-loader.js.cache.js",
+    "build": "node scripts/build",
     "build-test-binary": "cd test/binary && node-gyp rebuild && cp build/Release/hello.node ../integration/hello.node",
     "codecov": "codecov",
     "test": "npm run build-test-binary && npm run build && node --expose-gc --max_old_space_size=3072 node_modules/.bin/jest",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -116,7 +116,7 @@ module.exports = typescript;
   // copy typescript types
   await copy(
     __dirname + "/../node_modules/typescript/lib/*.ts",
-    __dirname + "/../dist/ncc/loaders/lib/"
+    __dirname + "/../dist/ncc/loaders/typescript/lib/"
   );
 
   for (const file of await glob(__dirname + "/../dist/**/*.js")) {


### PR DESCRIPTION
This provides the root fix to https://github.com/zeit/ncc/pull/445 without using the workaround.

Turns out it was as simple as the asset emission folder name changing!