### PR TITLE
Update to webpack-asset-relocator-loader@0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@google-cloud/firestore": "^2.2.0",
     "@sentry/node": "^4.3.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@zeit/webpack-asset-relocator-loader": "0.6.1",
+    "@zeit/webpack-asset-relocator-loader": "0.6.2",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zeit/webpack-asset-relocator-loader@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.6.1.tgz#1cd8f268a2a981acafc657ce8482183bbd46a51b"
-  integrity sha512-ywwDEJEV9cNk+PjGmUWgbewmy9f9G6UtRrC9xrKlrO7sHeU48aPwVPBp1vgqc2h7Zfjbmfb9jZ2pGAEIBclNvg==
+"@zeit/webpack-asset-relocator-loader@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.6.2.tgz#b15353d8578562f299eddb94d4b771297acc0487"
+  integrity sha512-IUz2YvFAv03LHP4dhjHqG549ecZhdp7KU8B+vGfJRgcDzvlCmc9CA1YcYfJHVO96U8dU5z85RIysr2whYUXmgQ==
   dependencies:
     sourcemap-codec "^1.4.4"
 


### PR DESCRIPTION
Release - https://github.com/zeit/webpack-asset-relocator-loader/releases/tag/0.6.2.

Resolves the following issues:

* https://github.com/zeit/ncc/issues/438
* https://github.com/zeit/ncc/issues/332
