### PR TITLE
Fix issue with TypeScript paths with `allowJs`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ module.exports = (
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory
   try {
-    resolvePlugins.push(new TsconfigPathsPlugin({ silent: true, extensions: [".ts", ".tsx", ".js"] }));
+    resolvePlugins.push(new TsconfigPathsPlugin({ silent: true, extensions: SUPPORTED_EXTENSIONS }));
 
     const tsconfig = tsconfigPaths.loadConfig();
     if (tsconfig.resultType === "success") {

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ module.exports = (
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory
   try {
-    resolvePlugins.push(new TsconfigPathsPlugin({ silent: true }));
+    resolvePlugins.push(new TsconfigPathsPlugin({ silent: true, extensions: [".ts", ".tsx", ".js"] }));
 
     const tsconfig = tsconfigPaths.loadConfig();
     if (tsconfig.resultType === "success") {

--- a/src/index.js
+++ b/src/index.js
@@ -71,9 +71,15 @@ module.exports = (
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory
   try {
-    resolvePlugins.push(new TsconfigPathsPlugin({ silent: true, extensions: SUPPORTED_EXTENSIONS }));
-
     const tsconfig = tsconfigPaths.loadConfig();
+    const fullTsconfig = require(tsconfig.configFileAbsolutePath)
+
+    const tsconfigPathsOptions = { silent: true }
+    if (fullTsconfig.compilerOptions.allowJs) {
+      tsconfigPathsOptions.extensions = SUPPORTED_EXTENSIONS
+    }
+    resolvePlugins.push(new TsconfigPathsPlugin(tsconfigPathsOptions));
+
     if (tsconfig.resultType === "success") {
       tsconfigMatchPath = tsconfigPaths.createMatchPath(tsconfig.absoluteBaseUrl, tsconfig.paths);
     }

--- a/test/unit/tsconfig-paths-allowjs/input.ts
+++ b/test/unit/tsconfig-paths-allowjs/input.ts
@@ -1,0 +1,3 @@
+import module from '@module';
+
+console.log(module);

--- a/test/unit/tsconfig-paths-allowjs/module.js
+++ b/test/unit/tsconfig-paths-allowjs/module.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/unit/tsconfig-paths-allowjs/output-coverage.js
+++ b/test/unit/tsconfig-paths-allowjs/output-coverage.js
@@ -1,0 +1,86 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(439);
+/******/ 	};
+/******/ 	// initialize runtime
+/******/ 	runtime(__webpack_require__);
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 306:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony default export */ __webpack_exports__["default"] = ({});
+
+
+/***/ }),
+
+/***/ 439:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var _module_1 = __webpack_require__(306);
+console.log(_module_1["default"]);
+
+
+/***/ })
+
+/******/ },
+/******/ function(__webpack_require__) { // webpackRuntimeModules
+/******/ 	"use strict";
+/******/ 
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	!function() {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = function(exports) {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ }
+);

--- a/test/unit/tsconfig-paths-allowjs/output.js
+++ b/test/unit/tsconfig-paths-allowjs/output.js
@@ -1,0 +1,66 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(468);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 17:
+/***/ (function() {
+
+eval("require")("@module");
+
+
+/***/ }),
+
+/***/ 468:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var _module_1 = __webpack_require__(17);
+console.log(_module_1["default"]);
+
+
+/***/ })
+
+/******/ });

--- a/test/unit/tsconfig-paths-allowjs/tsconfig.json
+++ b/test/unit/tsconfig-paths-allowjs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"baseUrl": ".",
+		"paths": {
+			"@*": ["./*"]
+		},
+		"allowJs": true
+	}
+}


### PR DESCRIPTION
Closes #469

I noticed something when I added the test, when you run the existing `output.js` of `tsconfig-paths` you also get "Cannot find module", not sure if the output there is intended to be different from `output-coverage.js`, but thought i'd point it out.

The `tsconfig-paths-allowjs/output-coverage.js` shows the difference between adding `js` to the extensions of `TsconfigPathsPlugin` and not having it.