### PR TITLE
Add API alias options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = (
   {
     cache,
     externals = [],
+    alias = [],
     filename = "index.js",
     minify = false,
     sourceMap = false,
@@ -107,6 +108,12 @@ module.exports = (
   else if (typeof externals === 'object')
     Object.keys(externals).forEach(external => externalMap.set(external, externals[external]));
 
+  const aliasMap = {};
+  if (Array.isArray(aliasMap))
+    alias.forEach(alias => aliasMap[alias[0]] = alias[1]);
+  else if (typeof alias === 'object')
+    Object.keys(alias).forEach(from => aliasMap[from] = alias[from]);
+
   let watcher, watchHandler, rebuildHandler;
 
   const compiler = webpack({
@@ -138,7 +145,8 @@ module.exports = (
       // webpack defaults to `module` and `main`, but that's
       // not really what node.js supports, so we reset it
       mainFields: ["main"],
-      plugins: resolvePlugins
+      plugins: resolvePlugins,
+      alias: aliasMap
     },
     // https://github.com/zeit/ncc/pull/29#pullrequestreview-177152175
     node: false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,9 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
     // find the name of the input file (e.g input.ts)
     const inputFile = fs.readdirSync(testDir).find(file => file.includes("input"));
     await ncc(`${testDir}/${inputFile}`, {
+      alias: {
+        'aliastest': `${testDir}/aliasmap.js`
+      },
       externals: {
         'externaltest': 'externalmapped'
       }

--- a/test/unit/alias/aliasmap.js
+++ b/test/unit/alias/aliasmap.js
@@ -1,0 +1,1 @@
+module.exports = 'alias'

--- a/test/unit/alias/input.js
+++ b/test/unit/alias/input.js
@@ -1,0 +1,3 @@
+const external = require('aliastest');
+
+console.log(external);

--- a/test/unit/alias/output-coverage.js
+++ b/test/unit/alias/output-coverage.js
@@ -1,0 +1,64 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(758);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 243:
+/***/ (function(module) {
+
+module.exports = 'alias'
+
+
+/***/ }),
+
+/***/ 758:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const external = __webpack_require__(243);
+
+console.log(external);
+
+
+/***/ })
+
+/******/ });

--- a/test/unit/alias/output.js
+++ b/test/unit/alias/output.js
@@ -1,0 +1,64 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(851);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 589:
+/***/ (function(module) {
+
+module.exports = 'alias'
+
+
+/***/ }),
+
+/***/ 851:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const external = __webpack_require__(589);
+
+console.log(external);
+
+
+/***/ })
+
+/******/ });


### PR DESCRIPTION
Exposing `alias` options allowing to map one module to another and bundle the mapped module into the final archive.

Rollup alternatives: https://github.com/rollup/plugins/tree/master/packages/alias

Related: https://github.com/zeit/ncc/pull/460