### PR TITLE
Add transpileOnly support for TS projects if needed

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,7 @@ Options:
   -e, --external [mod]     Skip bundling 'mod'. Can be used many times
   -q, --quiet              Disable build summaries / non-error outputs
   -w, --watch              Start a watched build
+  -t, --transpile-only     Use transpileOnly option with the ts-loader
   --v8-cache               Emit a build using the v8 compile cache
 `;
 
@@ -135,7 +136,9 @@ async function runCmd (argv, stdout, stderr) {
       "-q": "--quiet",
       "--watch": Boolean,
       "-w": "--watch",
-      "--v8-cache": Boolean
+      "--v8-cache": Boolean,
+      "--transpile-only": Boolean,
+      "-t": "--transpile-only",
     }, {
       permissive: false,
       argv
@@ -223,6 +226,7 @@ async function runCmd (argv, stdout, stderr) {
           cache: args["--no-cache"] ? false : undefined,
           watch: args["--watch"],
           v8cache: args["--v8-cache"],
+          transpileOnly: args["--transpile-only"],
           quiet
         }
       );

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ module.exports = (
     v8cache = false,
     filterAssetBase = process.cwd(),
     quiet = false,
-    debugLog = false
+    debugLog = false,
+    transpileOnly = false
   } = {}
 ) => {
   if (!quiet) {
@@ -177,6 +178,7 @@ module.exports = (
           {
             loader: eval('__dirname + "/loaders/ts-loader.js"'),
             options: {
+              transpileOnly,
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
                 outDir: '//',

--- a/test/cli.js
+++ b/test/cli.js
@@ -47,5 +47,9 @@
     expect (code, stdout, stderr) {
       return code === 1 && stderr.toString().indexOf('ts-error.ts(3,16)') !== -1 && stderr.toString().split('\n').length < 10;
     }
+  },
+  {
+    args: ["run", "-t", "test/fixtures/with-type-errors/ts-error.ts"],
+    expect: { code: 0 }
   }
 ]

--- a/test/fixtures/with-type-errors/ts-error.ts
+++ b/test/fixtures/with-type-errors/ts-error.ts
@@ -1,0 +1,5 @@
+require.extensions['.asdf'] = function () {};
+
+function p (x: Y) {
+
+}

--- a/test/fixtures/with-type-errors/tsconfig.json
+++ b/test/fixtures/with-type-errors/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "es2015"
+  }
+}


### PR DESCRIPTION
This allows us to build faster while we are developing.
(As we are not much interest about the type accuracy)

With some tests, we can gain upto 2X time reduction when building.
I assume the benefit will be more than this for massive projects.