### PR TITLE
Support `.js` imports from typescript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,13 @@ module.exports = (
           if (!err.missing || !err.missing.length)
             return callback(err);
           // make not found errors runtime errors
+          if (request.endsWith('.js'))
+            return resolve.call(resolver, context, path, request.slice(0, -3), resolveContext, function (err, result) {
+              if (!err) return callback(null, result);
+              if (!err.missing || !err.missing.length)
+                return callback(err);
+              callback(null, __dirname + '/@@notfound.js' + '?' + (externalMap.get(request) || request));
+            });
           callback(null, __dirname + '/@@notfound.js' + '?' + (externalMap.get(request) || request));
         });
       };

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ module.exports = (
           if (!err.missing || !err.missing.length)
             return callback(err);
           // make not found errors runtime errors
-          if (request.endsWith('.js'))
+          if (request.endsWith('.js') && context.issuer && (context.issuer.endsWith('.ts') || context.issuer.endsWith('.tsx')))
             return resolve.call(resolver, context, path, request.slice(0, -3), resolveContext, function (err, result) {
               if (!err) return callback(null, result);
               if (!err.missing || !err.missing.length)

--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,16 @@ module.exports = (
           if (!err) return callback(null, result);
           if (!err.missing || !err.missing.length)
             return callback(err);
-          // make not found errors runtime errors
+          // Allow .js resolutions to .tsx? from .tsx?
           if (request.endsWith('.js') && context.issuer && (context.issuer.endsWith('.ts') || context.issuer.endsWith('.tsx')))
             return resolve.call(resolver, context, path, request.slice(0, -3), resolveContext, function (err, result) {
               if (!err) return callback(null, result);
               if (!err.missing || !err.missing.length)
                 return callback(err);
+              // make not found errors runtime errors
               callback(null, __dirname + '/@@notfound.js' + '?' + (externalMap.get(request) || request));
             });
+          // make not found errors runtime errors
           callback(null, __dirname + '/@@notfound.js' + '?' + (externalMap.get(request) || request));
         });
       };

--- a/test/unit/ts-exts/dep-dep.ts
+++ b/test/unit/ts-exts/dep-dep.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/test/unit/ts-exts/dep.ts
+++ b/test/unit/ts-exts/dep.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/test/unit/ts-exts/dep.ts
+++ b/test/unit/ts-exts/dep.ts
@@ -1,1 +1,2 @@
-export default {};
+export { default } from './dep-dep.js';
+

--- a/test/unit/ts-exts/input.ts
+++ b/test/unit/ts-exts/input.ts
@@ -1,0 +1,3 @@
+import dep from './dep.js';
+
+console.log(dep);

--- a/test/unit/ts-exts/output-coverage.js
+++ b/test/unit/ts-exts/output-coverage.js
@@ -1,0 +1,69 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(368);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 43:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+exports.__esModule = true;
+exports["default"] = {};
+
+
+/***/ }),
+
+/***/ 368:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var dep_js_1 = __webpack_require__(43);
+console.log(dep_js_1["default"]);
+
+
+/***/ })
+
+/******/ });

--- a/test/unit/ts-exts/output-coverage.js
+++ b/test/unit/ts-exts/output-coverage.js
@@ -44,6 +44,18 @@ module.exports =
 /******/ ({
 
 /***/ 43:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var dep_dep_js_1 = __webpack_require__(119);
+exports["default"] = dep_dep_js_1["default"];
+
+
+/***/ }),
+
+/***/ 119:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";

--- a/test/unit/ts-exts/output.js
+++ b/test/unit/ts-exts/output.js
@@ -1,0 +1,69 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(578);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 578:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var dep_js_1 = __webpack_require__(975);
+console.log(dep_js_1["default"]);
+
+
+/***/ }),
+
+/***/ 975:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+exports.__esModule = true;
+exports["default"] = {};
+
+
+/***/ })
+
+/******/ });

--- a/test/unit/ts-exts/output.js
+++ b/test/unit/ts-exts/output.js
@@ -55,13 +55,25 @@ console.log(dep_js_1["default"]);
 
 /***/ }),
 
-/***/ 975:
+/***/ 668:
 /***/ (function(__unusedmodule, exports) {
 
 "use strict";
 
 exports.__esModule = true;
 exports["default"] = {};
+
+
+/***/ }),
+
+/***/ 975:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var dep_dep_js_1 = __webpack_require__(668);
+exports["default"] = dep_dep_js_1["default"];
 
 
 /***/ })

--- a/test/unit/ts-exts/tsconfig.json
+++ b/test/unit/ts-exts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"baseUrl": ".",
+		"paths": {
+			"@*": ["./*"]
+		}
+	}
+}


### PR DESCRIPTION
This resolves https://github.com/zeit/ncc/issues/508 in allowing the pattern for TypeScript code using `.js` extensions to reference other TypeScript files.

This is currently recommended by the TypeScript team (https://github.com/microsoft/TypeScript/issues/16577#issuecomment-309169829) as an approach for writing TypeScript that will include the file extensions in the output files when using `tsc` manually, resulting in Node.js and browser compatibility for the output.

With this PR, ncc doesn't have to break enabling this workflow for users, while remaining backwards compatible with the previous behaviour so it would be fine to release this as a minor.