### PR TITLE
Update CI badge in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ncc
 
-[![CI Status](https://badgen.net/github/checks/zeit/ncc?label=CI)](https://github.com/zeit/ncc/actions?workflow=CI)
+[![CI Status](https://github.com/zeit/ncc/workflows/CI/badge.svg)](https://github.com/zeit/ncc/actions?workflow=CI)
 [![codecov](https://codecov.io/gh/zeit/ncc/branch/master/graph/badge.svg)](https://codecov.io/gh/zeit/ncc)
 
 Simple CLI for compiling a Node.js module into a single file,

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ncc
 
-[![Build Status](https://circleci.com/gh/zeit/ncc.svg?&style=shield)](https://circleci.com/gh/zeit/workflows/ncc)
+[![CI Status](https://badgen.net/github/checks/zeit/ncc?label=CI)](https://github.com/zeit/ncc/actions?workflow=CI)
 [![codecov](https://codecov.io/gh/zeit/ncc/branch/master/graph/badge.svg)](https://codecov.io/gh/zeit/ncc)
 
 Simple CLI for compiling a Node.js module into a single file,


### PR DESCRIPTION
We moved from Circle CI to Actions CI in #494 but forgot to update the badge.